### PR TITLE
Users screen sdk integration

### DIFF
--- a/src/components/Screen/CoursesScreen/SearchCoursesFilter.tsx
+++ b/src/components/Screen/CoursesScreen/SearchCoursesFilter.tsx
@@ -8,7 +8,7 @@ import classes from './style.module.scss';
 
 export default function SearchCoursesFilter(): ReactElement {
   const [state, dispatch] = useCoursesContext();
-  const { courses } = state;
+  const { courses, coursesSearchValue } = state;
 
   const onSearch = (searchValue: string) => {
     const newCourseList = courses.filter(({ title }) =>
@@ -26,6 +26,7 @@ export default function SearchCoursesFilter(): ReactElement {
     <SearchFilter
       className={classes['search-courses-filter']}
       placeholder="Search course name"
+      value={coursesSearchValue}
       onSearch={onSearch}
     />
   );

--- a/src/components/Screen/CoursesScreen/index.tsx
+++ b/src/components/Screen/CoursesScreen/index.tsx
@@ -6,7 +6,6 @@ import { useCoursesContext, fetchCoursesData, ActionType } from '../../../provid
 import { UICourse } from '../../../walkme/data';
 import { IDateRange } from '../../../utils';
 
-import { useAppSkeleton } from '../../../hooks/skeleton';
 import AnalyticsCharts from '../../common/AnalyticsCharts';
 import ControlsWrapper from '../../common/ControlsWrapper';
 import { CreateButton } from '../../common/buttons';
@@ -43,9 +42,6 @@ export default function CoursesScreen(): ReactElement {
 
   // Unmount only
   useEffect(() => () => dispatch({ type: ActionType.ResetCourses }), [dispatch]);
-
-  // skeleton
-  const appInit = useAppSkeleton();
 
   const onMultiSelectChange = (selectedRowKeys: Array<Key>, selectedRows: Array<UICourse>) =>
     dispatch({

--- a/src/components/Screen/CoursesScreen/tableData.tsx
+++ b/src/components/Screen/CoursesScreen/tableData.tsx
@@ -6,13 +6,15 @@ import { SortableHandle } from 'react-sortable-hoc';
 import { PublishStatus, UICourse } from '../../../walkme/data';
 
 import { WMTagColor } from '../../common/WMTag';
-import DashCell from '../../common/tableCells/DashCell';
-import DragHandleCell from '../../common/tableCells/DragHandleCell';
-import LinkCell from '../../common/tableCells/LinkCell';
-import NumberCell from '../../common/tableCells/NumberCell';
-import StatusDotCell from '../../common/tableCells/StatusDotCell';
-import TagCell from '../../common/tableCells/TagCell';
-import TextArrayCell from '../../common/tableCells/TextArrayCell';
+import {
+  DashCell,
+  DragHandleCell,
+  LinkCell,
+  NumberCell,
+  StatusDotCell,
+  TagCell,
+  TextArrayCell,
+} from '../../common/tableCells';
 
 const DragHandle = SortableHandle(() => <DragHandleCell />);
 

--- a/src/components/Screen/UsersScreen/ShownUsersIndicator.tsx
+++ b/src/components/Screen/UsersScreen/ShownUsersIndicator.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement } from 'react';
+
+import { useUsersContext } from '../../../providers/UsersContext';
+
+import classes from './style.module.scss';
+
+export default function ShownUsersIndicator(): ReactElement {
+  const [{ filteredUsers, totals_unique_users, usersSearchValue }] = useUsersContext();
+
+  return (
+    <div className={classes['shown-users-indicator']}>
+      {usersSearchValue ? (
+        <>
+          Search
+          <span className={classes['search-result']}>{filteredUsers.length} Results found</span>
+        </>
+      ) : (
+        `${totals_unique_users} Users`
+      )}
+    </div>
+  );
+}

--- a/src/components/Screen/UsersScreen/index.tsx
+++ b/src/components/Screen/UsersScreen/index.tsx
@@ -38,8 +38,8 @@ export default function UsersScreen(): ReactElement {
     dispatch({ type: ActionType.SetDateRange, dateRange });
 
   const onSearch = (searchValue: string) => {
-    const newUsersList = users.filter(({ title }) =>
-      title.toLowerCase().includes(searchValue.toLowerCase()),
+    const newUsersList = users.filter(({ id }) =>
+      id.toLowerCase().includes(searchValue.toLowerCase()),
     );
 
     dispatch({
@@ -56,7 +56,7 @@ export default function UsersScreen(): ReactElement {
         timeFilterProps={{ onDateRangeChange, dateRange: { from, to } }}
       />
       <WMCard title={`${totals_unique_users} Users`}>
-        <WMTable data={filteredUsers} columns={columns}>
+        <WMTable className={classes['users-table']} data={filteredUsers} columns={columns}>
           <ControlsWrapper>
             {/* <DropdownFilter label="Course Name" options={courses} />
             <DropdownFilter label="Completed" options={statuses} />

--- a/src/components/Screen/UsersScreen/index.tsx
+++ b/src/components/Screen/UsersScreen/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
 
+import { useAppContext } from '../../../providers/AppContext';
 import {
   useUsersContext,
   fetchUsers,
@@ -24,6 +25,11 @@ import ShownUsersIndicator from './ShownUsersIndicator';
 import classes from './style.module.scss';
 
 export default function UsersScreen(): ReactElement {
+  const [appState] = useAppContext();
+  const {
+    system,
+    environment: { id: envId },
+  } = appState;
   const [state, dispatch] = useUsersContext();
   const {
     dateRange: { from, to },
@@ -33,8 +39,8 @@ export default function UsersScreen(): ReactElement {
   } = state;
 
   useEffect(() => {
-    fetchUsers(dispatch, 0, from, to);
-  }, [dispatch, from, to]);
+    fetchUsers(dispatch, envId, from, to);
+  }, [system, envId, dispatch, from, to]);
 
   // Unmount only
   useEffect(() => () => dispatch({ type: ActionType.ResetUsers }), [dispatch]);
@@ -71,7 +77,7 @@ export default function UsersScreen(): ReactElement {
           <ControlsWrapper>
             <ExportButton
               className={classes['export-btn']}
-              onClick={() => exportUsers(dispatch, 0, from, to)}
+              onClick={() => exportUsers(dispatch, envId, from, to)}
             />
             <SearchFilter placeholder="Search users" value={usersSearchValue} onSearch={onSearch} />
           </ControlsWrapper>

--- a/src/components/Screen/UsersScreen/index.tsx
+++ b/src/components/Screen/UsersScreen/index.tsx
@@ -15,6 +15,7 @@ import { ExportButton } from '../../common/buttons';
 
 // import { courses, statuses, results } from './utils';
 import { columns } from './tableData';
+import ShownUsersIndicator from './ShownUsersIndicator';
 import classes from './style.module.scss';
 
 export default function UsersScreen(): ReactElement {
@@ -23,7 +24,6 @@ export default function UsersScreen(): ReactElement {
     dateRange: { from, to },
     users,
     filteredUsers,
-    totals_unique_users,
     usersSearchValue,
   } = state;
 
@@ -55,13 +55,14 @@ export default function UsersScreen(): ReactElement {
         title="Users"
         timeFilterProps={{ onDateRangeChange, dateRange: { from, to } }}
       />
-      <WMCard title={`${totals_unique_users} Users`}>
+      <WMCard className={classes['table-wrapper']}>
         <WMTable className={classes['users-table']} data={filteredUsers} columns={columns}>
-          <ControlsWrapper>
-            {/* <DropdownFilter label="Course Name" options={courses} />
+          <ShownUsersIndicator />
+          {/* <ControlsWrapper>
+            <DropdownFilter label="Course Name" options={courses} />
             <DropdownFilter label="Completed" options={statuses} />
-            <DropdownFilter label="Quiz Results" options={results} /> */}
-          </ControlsWrapper>
+            <DropdownFilter label="Quiz Results" options={results} />
+          </ControlsWrapper> */}
           <ControlsWrapper>
             <ExportButton className={classes['export-btn']} />
             <SearchFilter placeholder="Search users" value={usersSearchValue} onSearch={onSearch} />

--- a/src/components/Screen/UsersScreen/index.tsx
+++ b/src/components/Screen/UsersScreen/index.tsx
@@ -1,76 +1,70 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 
-import { usersMockData } from '../../../constants/mocks/users-mock';
-import { data, columns } from '../../../constants/mocks/tableMockUsersData';
+import { useUsersContext, fetchUsers, ActionType } from '../../../providers/UsersContext';
+import { IDateRange } from '../../../utils';
+
 import WMCard from '../../common/WMCard';
 import WMTable from '../../common/WMTable';
 import ScreenHeader from '../../common/ScreenHeader';
 import ControlsWrapper from '../../common/ControlsWrapper';
-import DropdownFilter from '../../common/filters/DropdownFilter';
-import { IWMDropdownOption } from '../../common/WMDropdown';
-import SearchFilter from '../../common/filters/SearchFilter';
-import ExportButton from '../../common/buttons/ExportButton';
+import {
+  // DropdownFilter,
+  SearchFilter,
+} from '../../common/filters';
+import { ExportButton } from '../../common/buttons';
 
+// import { courses, statuses, results } from './utils';
+import { columns } from './tableData';
 import classes from './style.module.scss';
 
-interface IUserData {
-  key: string;
-  user: string;
-  courseName: string;
-  started: string;
-  completed: string;
-  timeToComplete: string;
-  quizResult: number;
-  noOfQuizAttempts: number;
-}
-
-const courses: IWMDropdownOption[] = [
-  { id: 0, value: 'All Courses' },
-  { id: 1, value: 'Course 1' },
-  { id: 2, value: 'Course 2' },
-  { id: 3, value: 'Course 3' },
-  { id: 4, value: 'Course 4' },
-  { id: 5, value: 'Course 5' },
-];
-
-const statuses: IWMDropdownOption[] = [
-  { id: 0, value: 'All' },
-  { id: 1, value: 'Completed' },
-  { id: 2, value: 'Did not complete' },
-];
-
-const results: IWMDropdownOption[] = [
-  { id: 0, value: 'All Results' },
-  { id: 1, value: 'Passed' },
-  { id: 2, value: 'Failed' },
-  { id: 3, value: 'Did not submit' },
-  { id: 4, value: 'No quiz' },
-];
-
 export default function UsersScreen(): ReactElement {
-  const { title: mainTitle, usersTable } = usersMockData;
-  const [tableData, setTableData] = useState(data);
+  const [state, dispatch] = useUsersContext();
+  const {
+    dateRange: { from, to },
+    users,
+    filteredUsers,
+    totals_unique_users,
+    usersSearchValue,
+  } = state;
+
+  useEffect(() => {
+    fetchUsers(dispatch, 0, from, to);
+  }, [dispatch, from, to]);
+
+  // Unmount only
+  useEffect(() => () => dispatch({ type: ActionType.ResetUsers }), [dispatch]);
+
+  const onDateRangeChange = (dateRange?: IDateRange) =>
+    dispatch({ type: ActionType.SetDateRange, dateRange });
 
   const onSearch = (searchValue: string) => {
-    const newTableData = data.filter((user) =>
-      user.user.toLowerCase().includes(searchValue.toLowerCase()),
+    const newUsersList = users.filter(({ title }) =>
+      title.toLowerCase().includes(searchValue.toLowerCase()),
     );
-    setTableData(newTableData);
+
+    dispatch({
+      type: ActionType.SetUsersSearchValue,
+      usersSearchValue: searchValue,
+      users: newUsersList,
+    });
   };
 
   return (
     <>
-      <ScreenHeader title={mainTitle} />
-      <WMCard title={`${tableData.length} ${usersTable.title}`}>
-        <WMTable data={tableData as Array<IUserData>} columns={columns}>
+      <ScreenHeader
+        title="Users"
+        timeFilterProps={{ onDateRangeChange, dateRange: { from, to } }}
+      />
+      <WMCard title={`${totals_unique_users} Users`}>
+        <WMTable data={filteredUsers} columns={columns}>
           <ControlsWrapper>
-            <DropdownFilter label="Course Name" options={courses} />
+            {/* <DropdownFilter label="Course Name" options={courses} />
             <DropdownFilter label="Completed" options={statuses} />
-            <DropdownFilter label="Quiz Results" options={results} />
+            <DropdownFilter label="Quiz Results" options={results} /> */}
           </ControlsWrapper>
           <ControlsWrapper>
             <ExportButton className={classes['export-btn']} />
-            <SearchFilter placeholder="Search users" onSearch={onSearch} />
+            <SearchFilter placeholder="Search users" value={usersSearchValue} onSearch={onSearch} />
           </ControlsWrapper>
         </WMTable>
       </WMCard>

--- a/src/components/Screen/UsersScreen/index.tsx
+++ b/src/components/Screen/UsersScreen/index.tsx
@@ -1,6 +1,11 @@
 import React, { ReactElement, useEffect } from 'react';
 
-import { useUsersContext, fetchUsers, ActionType } from '../../../providers/UsersContext';
+import {
+  useUsersContext,
+  fetchUsers,
+  exportUsers,
+  ActionType,
+} from '../../../providers/UsersContext';
 import { IDateRange } from '../../../utils';
 
 import WMCard from '../../common/WMCard';
@@ -64,7 +69,10 @@ export default function UsersScreen(): ReactElement {
             <DropdownFilter label="Quiz Results" options={results} />
           </ControlsWrapper> */}
           <ControlsWrapper>
-            <ExportButton className={classes['export-btn']} />
+            <ExportButton
+              className={classes['export-btn']}
+              onClick={() => exportUsers(dispatch, 0, from, to)}
+            />
             <SearchFilter placeholder="Search users" value={usersSearchValue} onSearch={onSearch} />
           </ControlsWrapper>
         </WMTable>

--- a/src/components/Screen/UsersScreen/style.module.scss
+++ b/src/components/Screen/UsersScreen/style.module.scss
@@ -1,3 +1,55 @@
-.export-btn {
-  margin-right: 20px;
+.table-wrapper:global(.ant-card) {
+  min-width: min-content;
+  min-height: 720px;
+
+  .shown-users-indicator {
+    font-family: var(--font-secondary);
+    font-size: 15px;
+    font-weight: 600;
+
+    .search-result {
+      font-size: 13px;
+      font-weight: 400;
+      font-style: italic;
+      margin-left: 13px;
+    }
+  }
+
+  .export-btn:global(.ant-btn) {
+    margin-right: 20px;
+  }
+
+  .users-table {
+    :global(.ant-table) {
+      font-family: var(--font-primary);
+      color: var(--neutral900);
+
+      .user-cell {
+        width: 150px;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .started-cell {
+        min-width: 86px;
+      }
+
+      .completed-cell,
+      .duration-cell,
+      .attempts-cell {
+        min-width: 120px;
+      }
+
+      .result-cell {
+        min-width: 105px;
+      }
+
+      .result-cell,
+      .attempts-cell {
+        text-align: right;
+      }
+    }
+  }
 }

--- a/src/components/Screen/UsersScreen/tableData.tsx
+++ b/src/components/Screen/UsersScreen/tableData.tsx
@@ -12,17 +12,21 @@ import {
   SubtextCell,
 } from '../../common/tableCells';
 
+import classes from './style.module.scss';
+
 const tableDateFormat = 'MMM. D, YYYY';
 
 export const columns: ColumnsType<any> = [
   {
     title: 'User',
     dataIndex: UsersColumn.ID,
-    render: (value: string): ReactElement => <TextCell value={<b>{value}</b>} />,
+    render: (value: string): ReactElement => (
+      <TextCell className={classes['user-cell']} value={value} />
+    ),
   },
   {
     title: 'Course Name',
-    dataIndex: UsersColumn.COURSE_ID,
+    dataIndex: 'title',
     render: (value: string): ReactElement => <TextCell value={value} />,
   },
   {
@@ -32,7 +36,9 @@ export const columns: ColumnsType<any> = [
       const range = moment(value).fromNow();
       const formattedDate = moment(value).format(tableDateFormat);
 
-      return <SubtextCell value={range} subtext={formattedDate} />;
+      return (
+        <SubtextCell className={classes['started-cell']} value={range} subtext={formattedDate} />
+      );
     },
   },
   {
@@ -43,9 +49,9 @@ export const columns: ColumnsType<any> = [
       const formattedDate = moment(value).format(tableDateFormat);
 
       return value ? (
-        <SubtextCell value={range} subtext={formattedDate} />
+        <SubtextCell className={classes['completed-cell']} value={range} subtext={formattedDate} />
       ) : (
-        <WarningCell value="Did not complete" />
+        <WarningCell className={classes['completed-cell']} value="Did not complete" />
       );
     },
   },
@@ -53,7 +59,11 @@ export const columns: ColumnsType<any> = [
     title: 'Time to Complete',
     dataIndex: UsersColumn.TIME_TO_COMPLETE,
     render: (value: string): ReactElement =>
-      value ? <NumberCell value={value} /> : <WarningCell value="Did not complete" />,
+      value ? (
+        <NumberCell className={classes['duration-cell']} value={value} />
+      ) : (
+        <WarningCell className={classes['duration-cell']} value="Did not complete" />
+      ),
   },
   {
     title: 'Quiz Result',
@@ -61,9 +71,9 @@ export const columns: ColumnsType<any> = [
     align: 'right',
     render: (value: number): ReactElement =>
       value ? (
-        <StatusDotCell value={value} passingValue={66} />
+        <StatusDotCell className={classes['result-cell']} value={value} passingValue={66} />
       ) : (
-        <WarningCell value="Did not submit" />
+        <WarningCell className={classes['result-cell']} value="Did not submit" />
       ),
   },
   {
@@ -71,6 +81,10 @@ export const columns: ColumnsType<any> = [
     dataIndex: UsersColumn.QUIZ_ATTEMPTS,
     align: 'right',
     render: (value: string): ReactElement =>
-      value ? <NumberCell value={value} /> : <WarningCell value="Did not complete" />,
+      value ? (
+        <NumberCell className={classes['attempts-cell']} value={value} />
+      ) : (
+        <WarningCell className={classes['attempts-cell']} value="Did not complete" />
+      ),
   },
 ];

--- a/src/components/Screen/UsersScreen/tableData.tsx
+++ b/src/components/Screen/UsersScreen/tableData.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react/display-name */
+import { ColumnsType } from 'antd/lib/table';
+import React, { ReactElement } from 'react';
+import moment from 'moment';
+
+import { UsersColumn } from '../../../walkme/models';
+import {
+  TextCell,
+  WarningCell,
+  NumberCell,
+  StatusDotCell,
+  SubtextCell,
+} from '../../common/tableCells';
+
+const tableDateFormat = 'MMM. D, YYYY';
+
+export const columns: ColumnsType<any> = [
+  {
+    title: 'User',
+    dataIndex: UsersColumn.ID,
+    render: (value: string): ReactElement => <TextCell value={<b>{value}</b>} />,
+  },
+  {
+    title: 'Course Name',
+    dataIndex: UsersColumn.COURSE_ID,
+    render: (value: string): ReactElement => <TextCell value={value} />,
+  },
+  {
+    title: 'Started',
+    dataIndex: UsersColumn.STARTED_DATE,
+    render: (value: Date): ReactElement => {
+      const range = moment(value).fromNow();
+      const formattedDate = moment(value).format(tableDateFormat);
+
+      return <SubtextCell value={range} subtext={formattedDate} />;
+    },
+  },
+  {
+    title: 'Completed',
+    dataIndex: UsersColumn.COMPLETED_DATE,
+    render: (value: Date): ReactElement => {
+      const range = moment(value).fromNow();
+      const formattedDate = moment(value).format(tableDateFormat);
+
+      return value ? (
+        <SubtextCell value={range} subtext={formattedDate} />
+      ) : (
+        <WarningCell value="Did not complete" />
+      );
+    },
+  },
+  {
+    title: 'Time to Complete',
+    dataIndex: UsersColumn.TIME_TO_COMPLETE,
+    render: (value: string): ReactElement =>
+      value ? <NumberCell value={value} /> : <WarningCell value="Did not complete" />,
+  },
+  {
+    title: 'Quiz Result',
+    dataIndex: UsersColumn.QUIZ_RESULT,
+    align: 'right',
+    render: (value: number): ReactElement =>
+      value ? (
+        <StatusDotCell value={value} passingValue={66} />
+      ) : (
+        <WarningCell value="Did not submit" />
+      ),
+  },
+  {
+    title: 'No. of quiz attempts',
+    dataIndex: UsersColumn.QUIZ_ATTEMPTS,
+    align: 'right',
+    render: (value: string): ReactElement =>
+      value ? <NumberCell value={value} /> : <WarningCell value="Did not complete" />,
+  },
+];

--- a/src/components/Screen/UsersScreen/utils.ts
+++ b/src/components/Screen/UsersScreen/utils.ts
@@ -1,0 +1,24 @@
+import { IWMDropdownOption } from '../../common/WMDropdown';
+
+export const courses: IWMDropdownOption[] = [
+  { id: 0, value: 'All Courses' },
+  { id: 1, value: 'Course 1' },
+  { id: 2, value: 'Course 2' },
+  { id: 3, value: 'Course 3' },
+  { id: 4, value: 'Course 4' },
+  { id: 5, value: 'Course 5' },
+];
+
+export const statuses: IWMDropdownOption[] = [
+  { id: 0, value: 'All' },
+  { id: 1, value: 'Completed' },
+  { id: 2, value: 'Did not complete' },
+];
+
+export const results: IWMDropdownOption[] = [
+  { id: 0, value: 'All Results' },
+  { id: 1, value: 'Passed' },
+  { id: 2, value: 'Failed' },
+  { id: 3, value: 'Did not submit' },
+  { id: 4, value: 'No quiz' },
+];

--- a/src/components/Screen/index.tsx
+++ b/src/components/Screen/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../constants/routes';
 import CourseEditorProvider from '../../providers/CourseEditorContext';
 import CoursesProvider from '../../providers/CoursesContext';
+import UsersProvider from '../../providers/UsersContext';
 
 import SplashScreen from './SplashScreen';
 import ErrorScreen from './ErrorScreen';
@@ -35,7 +36,9 @@ export default function Screen(): ReactElement {
           <CourseScreen />
         </Route>
         <Route path={USERS_ROUTE.path}>
-          <UsersScreen />
+          <UsersProvider>
+            <UsersScreen />
+          </UsersProvider>
         </Route>
         <Route path={[NEW_COURSE_EDITOR_ROUTE.path, COURSE_EDITOR_ROUTE.path]}>
           <CourseEditorProvider>

--- a/src/components/common/buttons/ExportButton/index.tsx
+++ b/src/components/common/buttons/ExportButton/index.tsx
@@ -19,16 +19,16 @@ export default function ExportButton({
   const appInit = useAppSkeleton();
 
   return (
-    <div className={classes['export-button']}>
+    <>
       {appInit ? (
         <WMButton
-          className={cc([classes['export-wmbutton'], className])}
+          className={cc([classes['export-button'], className])}
           onClick={onClick}
           icon={<Icon type={IconType.FileExport} />}
         />
       ) : (
-        <WMSkeletonButton active shape="square" />
+        <WMSkeletonButton className={classes['skeleton']} active shape="square" />
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/common/buttons/ExportButton/style.module.scss
+++ b/src/components/common/buttons/ExportButton/style.module.scss
@@ -1,10 +1,9 @@
-.export-button {
-  .export-wmbutton:global(.ant-btn) {
-    font-size: 16px;
-  }
+.export-button:global(.ant-btn) {
+  font-size: 16px;
+  color: var(--primary);
+}
 
-  :global(.ant-skeleton.ant-skeleton-active .ant-skeleton-button) {
-    width: 30px;
-    margin: 0 5px;
-  }
+.skeleton:global(.ant-skeleton.ant-skeleton-active .ant-skeleton-button) {
+  width: 30px;
+  margin: 0 5px;
 }

--- a/src/components/common/tableCells/SubtextCell.tsx
+++ b/src/components/common/tableCells/SubtextCell.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import cc from 'classcat';
 
 import { ISubtextCell } from './tableCells.interface';
 import classes from './style.module.scss';
 
-export default function SubtextCell({ value, subtext, className, ...otherProps }: ISubtextCell) {
+export default function SubtextCell({
+  value,
+  subtext,
+  className,
+  ...otherProps
+}: ISubtextCell): ReactElement {
   return (
     <div className={cc([classes['subtext-cell'], className])} {...otherProps}>
       <div className={classes.text}>{value}</div>

--- a/src/components/common/tableCells/TextCell.tsx
+++ b/src/components/common/tableCells/TextCell.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { ITextCell } from './tableCells.interface';
 
-export default function TextCell({ value, className, ...otherProps }: ITextCell) {
+export default function TextCell({ value, className, ...otherProps }: ITextCell): ReactElement {
   return (
-    <span className={className} {...otherProps}>
+    <div className={className} {...otherProps}>
       {value}
-    </span>
+    </div>
   );
 }

--- a/src/components/common/tableCells/WarningCell.tsx
+++ b/src/components/common/tableCells/WarningCell.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { ITextCell } from './tableCells.interface';
 import TextCell from './TextCell';
 
-export default function WarningCell({ value, className, ...otherProps }: ITextCell) {
+export default function WarningCell({ value, className, ...otherProps }: ITextCell): ReactElement {
   return <TextCell value={`⊘ ${value}`} className={className} {...otherProps} />;
 }

--- a/src/components/common/tableCells/index.ts
+++ b/src/components/common/tableCells/index.ts
@@ -1,0 +1,27 @@
+import DashCell from './DashCell';
+import DragHandleCell from './DragHandleCell';
+import IconTextCell from './IconTextCell';
+import LinkCell from './LinkCell';
+import NumberCell from './NumberCell';
+import StatusDotCell from './StatusDotCell';
+import SubtextCell from './SubtextCell';
+import TagCell from './TagCell';
+import TextArrayCell from './TextArrayCell';
+import TextCell from './TextCell';
+import WarningCell from './WarningCell';
+
+export * from './tableCells.interface';
+
+export {
+  DashCell,
+  DragHandleCell,
+  IconTextCell,
+  LinkCell,
+  NumberCell,
+  StatusDotCell,
+  SubtextCell,
+  TagCell,
+  TextArrayCell,
+  TextCell,
+  WarningCell,
+};

--- a/src/providers/UsersContext/actions.ts
+++ b/src/providers/UsersContext/actions.ts
@@ -1,0 +1,11 @@
+export enum ActionType {
+  FetchUsers = 'FETCH_USERS',
+  FetchUsersSuccess = 'FETCH_USERS_SUCCESS',
+  FetchUsersError = 'FETCH_USERS_ERROR',
+  SetUsersSearchValue = 'SET_USERS_SEARCH_VALUE',
+  SetDateRange = 'SET_DATE_RANGE',
+  ExportUsers = 'EXPORT_USERS',
+  ExportUsersSuccess = 'EXPORT_USERS_SUCCESS',
+  ExportUsersError = 'EXPORT_USERS_ERROR',
+  ResetUsers = 'RESET_USERS',
+}

--- a/src/providers/UsersContext/index.tsx
+++ b/src/providers/UsersContext/index.tsx
@@ -1,0 +1,25 @@
+import React, { useReducer, ReactElement } from 'react';
+
+import { ActionType, IAction, IState, IDispatch, IUsersProvider } from './users-context.interface';
+import {
+  UsersStateContext,
+  UsersDispatchContext,
+  useUsersContext,
+  fetchUsers,
+  exportUsers,
+} from './utils';
+import { reducer, initialState } from './reducer';
+
+export type { IAction, IState, IDispatch, IUsersProvider };
+
+export { useUsersContext, fetchUsers, exportUsers, reducer, initialState, ActionType };
+
+export default function UsersProvider({ children }: IUsersProvider): ReactElement {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <UsersStateContext.Provider value={state}>
+      <UsersDispatchContext.Provider value={dispatch}>{children}</UsersDispatchContext.Provider>
+    </UsersStateContext.Provider>
+  );
+}

--- a/src/providers/UsersContext/reducer.ts
+++ b/src/providers/UsersContext/reducer.ts
@@ -1,0 +1,65 @@
+import produce from 'immer';
+
+import { defaultDateRange } from '../../utils';
+
+import { ActionType, IState, IAction } from './users-context.interface';
+
+export const initialState = {
+  isFetchingUsers: false,
+  isFetchingUsersError: false,
+  dateRange: defaultDateRange,
+  users: [],
+  totals_unique_users: 0,
+  filteredUsers: [],
+  usersSearchValue: '',
+  isExportingUsers: false,
+  isExportingUsersError: false,
+} as IState;
+
+export const reducer = produce(
+  (draft: IState, action: IAction): IState => {
+    switch (action.type) {
+      case ActionType.FetchUsers:
+        draft.isFetchingUsers = true;
+        draft.isFetchingUsersError = false;
+        break;
+      case ActionType.FetchUsersSuccess:
+        draft.isFetchingUsers = false;
+        draft.isFetchingUsersError = false;
+        draft.users = action.users ?? initialState.users;
+        draft.filteredUsers = action.users ?? initialState.filteredUsers;
+        draft.totals_unique_users = action.totals_unique_users ?? initialState.totals_unique_users;
+        break;
+      case ActionType.FetchUsersError:
+        draft.isFetchingUsers = false;
+        draft.isFetchingUsersError = true;
+        break;
+      case ActionType.SetUsersSearchValue:
+        draft.usersSearchValue = action.usersSearchValue ?? initialState.usersSearchValue;
+        draft.filteredUsers = action.users ?? initialState.filteredUsers;
+        break;
+      case ActionType.SetDateRange:
+        draft.dateRange = action.dateRange ?? initialState.dateRange;
+        break;
+      case ActionType.ExportUsers:
+        draft.isExportingUsers = true;
+        draft.isExportingUsersError = false;
+        break;
+      case ActionType.ExportUsersSuccess:
+        draft.isExportingUsers = false;
+        draft.isExportingUsersError = false;
+        break;
+      case ActionType.ExportUsersError:
+        draft.isExportingUsers = false;
+        draft.isExportingUsersError = true;
+        break;
+      case ActionType.ResetUsers:
+        draft = { ...initialState };
+        break;
+      default:
+        throw new Error(`Unhandled action type: ${action.type}`);
+    }
+
+    return draft;
+  },
+);

--- a/src/providers/UsersContext/users-context.interface.ts
+++ b/src/providers/UsersContext/users-context.interface.ts
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react';
+
+import { UserListUILineItem } from '../../walkme/models';
+import { IDateRange } from '../../utils';
+
+import { ActionType } from './actions';
+
+export { ActionType };
+
+export interface IAction {
+  type: ActionType;
+  users?: Array<UserListUILineItem>;
+  totals_unique_users?: number;
+  dateRange?: IDateRange;
+  usersSearchValue?: string;
+}
+
+export interface IDispatch {
+  (action: IAction): void;
+}
+
+export interface IState {
+  isFetchingUsers: boolean;
+  isFetchingUsersError: boolean;
+  dateRange: IDateRange;
+  users: Array<UserListUILineItem>;
+  totals_unique_users: number;
+  filteredUsers: Array<UserListUILineItem>;
+  usersSearchValue: string;
+  isExportingUsers: boolean;
+  isExportingUsersError: boolean;
+}
+
+export interface IUsersProvider {
+  children: ReactNode;
+}

--- a/src/providers/UsersContext/utils.ts
+++ b/src/providers/UsersContext/utils.ts
@@ -41,6 +41,7 @@ export const fetchUsers = async (
   dispatch({ type: ActionType.FetchUsers });
 
   try {
+    // TODO: utilize 'load more' button using 'first_item_index'
     const { data: users } = await getUsersList(envId, from, to, options);
     const { totals_unique_users } = await getUsersCount(envId, from, to, options);
 

--- a/src/providers/UsersContext/utils.ts
+++ b/src/providers/UsersContext/utils.ts
@@ -33,7 +33,7 @@ export const useUsersContext = (): [IState, IDispatch] => [useUsersState(), useU
 
 export const fetchUsers = async (
   dispatch: IDispatch,
-  envId = 0,
+  envId: number,
   from: string,
   to: string,
   options?: UsersListQueryOptions,
@@ -54,7 +54,7 @@ export const fetchUsers = async (
 
 export const exportUsers = async (
   dispatch: IDispatch,
-  envId = 0,
+  envId: number,
   from: string,
   to: string,
 ): Promise<void> => {

--- a/src/providers/UsersContext/utils.ts
+++ b/src/providers/UsersContext/utils.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 
 import { getUsersList, getUsersCount, exportUsersData } from '../../walkme';
-import { UsersListQueryOptions } from '../../walkme/models';
+import { UsersListQueryOptions, UsersColumn, UsersOrder } from '../../walkme/models';
 import { wmMessage, MessageType } from '../../utils';
 
 import { ActionType, IState, IDispatch } from './users-context.interface';
@@ -57,11 +57,16 @@ export const exportUsers = async (
   envId = 0,
   from: string,
   to: string,
-  options: UsersListQueryOptions,
 ): Promise<void> => {
   dispatch({ type: ActionType.ExportUsers });
 
   try {
+    const options = {
+      first_item_index: 0,
+      num_of_records: 100,
+      sort_by: UsersColumn.ID,
+      sort_by_order: UsersOrder.ASC,
+    };
     await exportUsersData(envId, from, to, options);
 
     dispatch({ type: ActionType.ExportUsersSuccess });

--- a/src/providers/UsersContext/utils.ts
+++ b/src/providers/UsersContext/utils.ts
@@ -1,0 +1,73 @@
+import { createContext, useContext } from 'react';
+
+import { getUsersList, getUsersCount, exportUsersData } from '../../walkme';
+import { UsersListQueryOptions } from '../../walkme/models';
+import { wmMessage, MessageType } from '../../utils';
+
+import { ActionType, IState, IDispatch } from './users-context.interface';
+
+export const UsersStateContext = createContext<IState | undefined>(undefined);
+export const UsersDispatchContext = createContext<IDispatch | undefined>(undefined);
+
+const useUsersState = () => {
+  const context = useContext(UsersStateContext);
+
+  if (context === undefined) {
+    throw new Error('useUsersState must be used within a UsersProvider');
+  }
+
+  return context;
+};
+
+const useUsersDispatch = () => {
+  const context = useContext(UsersDispatchContext);
+
+  if (context === undefined) {
+    throw new Error('useUsersDispatch must be used within a UsersProvider');
+  }
+
+  return context;
+};
+
+export const useUsersContext = (): [IState, IDispatch] => [useUsersState(), useUsersDispatch()];
+
+export const fetchUsers = async (
+  dispatch: IDispatch,
+  envId = 0,
+  from: string,
+  to: string,
+  options: UsersListQueryOptions,
+): Promise<void> => {
+  dispatch({ type: ActionType.FetchUsers });
+
+  try {
+    const { data: users } = await getUsersList(envId, from, to, options);
+    const { totals_unique_users } = await getUsersCount(envId, from, to, options);
+
+    dispatch({ type: ActionType.FetchUsersSuccess, users, totals_unique_users });
+  } catch (error) {
+    console.error(error);
+    dispatch({ type: ActionType.FetchUsersError });
+  }
+};
+
+export const exportUsers = async (
+  dispatch: IDispatch,
+  envId = 0,
+  from: string,
+  to: string,
+  options: UsersListQueryOptions,
+): Promise<void> => {
+  dispatch({ type: ActionType.ExportUsers });
+
+  try {
+    await exportUsersData(envId, from, to, options);
+
+    dispatch({ type: ActionType.ExportUsersSuccess });
+    wmMessage('Export completed');
+  } catch (error) {
+    console.error(error);
+    dispatch({ type: ActionType.ExportUsersError });
+    wmMessage('Export failed', MessageType.Error);
+  }
+};

--- a/src/providers/UsersContext/utils.ts
+++ b/src/providers/UsersContext/utils.ts
@@ -36,7 +36,7 @@ export const fetchUsers = async (
   envId = 0,
   from: string,
   to: string,
-  options: UsersListQueryOptions,
+  options?: UsersListQueryOptions,
 ): Promise<void> => {
   dispatch({ type: ActionType.FetchUsers });
 

--- a/src/walkme/analytics/users/list.ts
+++ b/src/walkme/analytics/users/list.ts
@@ -38,7 +38,7 @@ export function getUsersList(
   environment: number,
   from: string,
   to: string,
-  options: UsersListQueryOptions,
+  options?: UsersListQueryOptions,
 ): Promise<UsersResponse> {
   const combinedOptions = { ...DEFAULT_OPTIONS, ...options };
   const query = new URLSearchParams();

--- a/src/walkme/data/users.ts
+++ b/src/walkme/data/users.ts
@@ -14,7 +14,7 @@ export async function getUsersList(
   environment: number,
   from: string,
   to: string,
-  options: UsersListQueryOptions,
+  options?: UsersListQueryOptions,
 ): Promise<UserListUIResponse> {
   const usersData = await users.getUsersList(environment, from, to, options);
   return {

--- a/src/walkme/screens/users.ts
+++ b/src/walkme/screens/users.ts
@@ -19,7 +19,7 @@ export function getUsersList(
   environment: number,
   from: string,
   to: string,
-  options: UsersListQueryOptions,
+  options?: UsersListQueryOptions,
 ): Promise<UserListUIResponse> {
   return data.getUsersList(environment, from, to, options);
 }
@@ -35,7 +35,7 @@ export function getUsersCount(
   environment: number,
   from: string,
   to: string,
-  options: UsersCountQueryOptions,
+  options?: UsersCountQueryOptions,
 ): Promise<UsersCountResponse> {
   return analytics.getUsersCount(environment, from, to, options);
 }


### PR DESCRIPTION
- Some leftover fixes in `CoursesScreen`.
- Added `UsersProvider`.
- Update `UsersScreen` styles to match design.
- Integrate `UsersScreen` with SDK (updated necessary 'walkme' files).
- Fix `ExportButton` styles.
- Utilize export button.

TOD:
- Utilize 'Load more' button and fetch more users on top of existing list using `first_item_index`.
- Display total results at the bottom of the screen.
- Implement search by id with SDK, or leave it as is (filter only the visible list)?