### PR TITLE
Course settings

### DIFF
--- a/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
@@ -31,9 +31,8 @@ export default function CourseItemsList({
 
   const handleItemClick = (item: ContentItem) => {
     dispatch({
-      type: ActionType.ToggleDetailsPanel,
+      type: ActionType.OpenDetailsPanel,
       activeDetailsItem: { type: DetailsPanelSettingsType.Item, id: item.id as number },
-      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
@@ -33,6 +33,7 @@ export default function CourseItemsList({
     dispatch({
       type: ActionType.ToggleDetailsPanel,
       activeDetailsItem: { type: DetailsPanelSettingsType.Item, id: item.id as number },
+      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
@@ -33,7 +33,6 @@ export default function CourseItemsList({
         getChildPayload={(i) => items[i]}
         onDrop={onDrop}
         dragClass={classes['card-ghost']}
-        dragHandleSelector=".drag-handle"
       >
         {items.length ? (
           items.map((item, i) => (

--- a/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseItemsList/index.tsx
@@ -3,6 +3,9 @@ import { Container } from 'react-smooth-dnd';
 import { ContentItem } from '@walkme/types';
 import cc from 'classcat';
 
+import { ActionType, useCourseEditorContext } from '../../../../providers/CourseEditorContext';
+import { DetailsPanelSettingsType } from '../../../../providers/CourseEditorContext/course-editor-context.interface';
+
 import TaskItem from '../TaskItem';
 
 import classes from './style.module.scss';
@@ -12,7 +15,6 @@ export interface ICourseItemsList {
   className?: string;
   onDrop?: any;
   emptyState?: ReactNode;
-  handleItemClick?: (item: ContentItem) => void;
   taskItemProps?: any;
   [key: string]: any;
 }
@@ -21,11 +23,19 @@ export default function CourseItemsList({
   items,
   onDrop,
   className,
-  handleItemClick,
   emptyState,
   taskItemProps = {},
   ...otherProps
 }: ICourseItemsList): ReactElement {
+  const [state, dispatch] = useCourseEditorContext();
+
+  const handleItemClick = (item: ContentItem) => {
+    dispatch({
+      type: ActionType.ToggleDetailsPanel,
+      activeDetailsItem: { type: DetailsPanelSettingsType.Item, id: item.id as number },
+    });
+  };
+
   return (
     <div className={cc([classes['course-items-list'], className])}>
       <Container

--- a/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
@@ -8,6 +8,8 @@ import WMTabs, { WMTabPanel } from '../../common/WMTabs';
 
 import CourseOutlineTab from './CourseOutlineTab';
 import classes from './style.module.scss';
+import CourseSettingsTab from './CourseSettingsTab';
+import ActionMenu from './ActionMenu';
 
 enum TabId {
   CourseOutline = 'course-outline',
@@ -15,7 +17,7 @@ enum TabId {
 }
 
 export default function CourseOutline(): ReactElement {
-  const [state, dispatch] = useCourseEditorContext();
+  const [state] = useCourseEditorContext();
   const { isDetailsPanelOpen } = state;
 
   const tabs = [
@@ -27,7 +29,7 @@ export default function CourseOutline(): ReactElement {
     {
       id: TabId.Settings,
       title: 'Settings',
-      content: null, // TODO: add content
+      content: <CourseSettingsTab />,
     },
   ];
 

--- a/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
@@ -28,11 +28,7 @@ export default function CourseOutline(): ReactElement {
       title: 'Settings',
       content: <CourseSettingsTab />,
       onClick: () => {
-        dispatch({
-          type: ActionType.ToggleDetailsPanel,
-          activeDetailsItem: null,
-          openDetailsPanel: false,
-        });
+        dispatch({ type: ActionType.CloseDetailsPanel });
       },
     },
   ];

--- a/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react';
 import WMCard from '../../common/WMCard';
 import WMTabs, { WMTabPanel } from '../../common/WMTabs';
 
+import { ActionType, useCourseEditorContext } from '../../../providers/CourseEditorContext';
 import CourseOutlineTab from './CourseOutlineTab';
 import classes from './style.module.scss';
 import CourseSettingsTab from './CourseSettingsTab';
@@ -14,6 +15,8 @@ enum TabId {
 }
 
 export default function CourseOutline(): ReactElement {
+  const [state, dispatch] = useCourseEditorContext();
+
   const tabs = [
     {
       id: TabId.CourseOutline,
@@ -24,13 +27,31 @@ export default function CourseOutline(): ReactElement {
       id: TabId.Settings,
       title: 'Settings',
       content: <CourseSettingsTab />,
+      onClick: () => {
+        dispatch({
+          type: ActionType.ToggleDetailsPanel,
+          activeDetailsItem: null,
+          openDetailsPanel: false,
+        });
+      },
     },
   ];
+
+  const onTabClick = (key: string) => {
+    const tabItem = tabs.find((tab) => tab.id === key);
+    if (tabItem && tabItem.onClick) {
+      tabItem.onClick();
+    }
+  };
 
   return (
     <>
       <WMCard className={classes['course-structure']}>
-        <WMTabs className={classes['tabs']} defaultActiveKey={TabId.CourseOutline}>
+        <WMTabs
+          className={classes['tabs']}
+          defaultActiveKey={TabId.CourseOutline}
+          onTabClick={onTabClick}
+        >
           {tabs.map(({ id, title, content }) => (
             <WMTabPanel tab={title} key={id}>
               {content}

--- a/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutline.tsx
@@ -1,7 +1,4 @@
 import React, { ReactElement } from 'react';
-import cc from 'classcat';
-
-import { useCourseEditorContext } from '../../../providers/CourseEditorContext';
 
 import WMCard from '../../common/WMCard';
 import WMTabs, { WMTabPanel } from '../../common/WMTabs';
@@ -9,7 +6,7 @@ import WMTabs, { WMTabPanel } from '../../common/WMTabs';
 import CourseOutlineTab from './CourseOutlineTab';
 import classes from './style.module.scss';
 import CourseSettingsTab from './CourseSettingsTab';
-import ActionMenu from './ActionMenu';
+import CourseOutlineDetailsPanel from './CourseOutlineDetailsPanel/CourseOutlineDetailsPanel';
 
 enum TabId {
   CourseOutline = 'course-outline',
@@ -17,9 +14,6 @@ enum TabId {
 }
 
 export default function CourseOutline(): ReactElement {
-  const [state] = useCourseEditorContext();
-  const { isDetailsPanelOpen } = state;
-
   const tabs = [
     {
       id: TabId.CourseOutline,
@@ -44,10 +38,7 @@ export default function CourseOutline(): ReactElement {
           ))}
         </WMTabs>
       </WMCard>
-      <WMCard
-        className={cc([classes['details-panel'], { [classes['open']]: isDetailsPanelOpen }])}
-        title={<div className={classes['title']}>Some Details</div>}
-      />
+      <CourseOutlineDetailsPanel />
     </>
   );
 }

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineDetailsPanel/CourseOutlineDetailsPanel.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineDetailsPanel/CourseOutlineDetailsPanel.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from 'react';
+
+import { ActionType, useCourseEditorContext } from '../../../../providers/CourseEditorContext';
+import DetailsPanel from '../../../common/DetailsPanel';
+import Icon, { IconType } from '../../../common/Icon';
+import QuizSettingsForm from '../QuizSettingsForm';
+
+export default function CourseOutlineDetailsPanel(): ReactElement {
+  const [state, dispatch] = useCourseEditorContext();
+  const { isDetailsPanelOpen } = state;
+
+  const onClosePanel = (callback?: () => void) => {
+    dispatch({ type: ActionType.ToggleDetailsPanel });
+
+    if (callback) {
+      callback();
+    }
+  };
+
+  const detailsPanel = [
+    {
+      id: 'QuizSettings',
+      iconType: 'QuizSettings',
+      title: 'Quiz Settings',
+      content: <QuizSettingsForm courseId={state.course?.id ?? 0} />,
+      onClose: () => console.log('closing'),
+    },
+  ];
+
+  return (
+    <DetailsPanel
+      title={detailsPanel[0].title}
+      titleIcon={<Icon type={IconType[detailsPanel[0].iconType as keyof typeof IconType]} />}
+      isOpen={isDetailsPanelOpen}
+      onClose={() => onClosePanel(detailsPanel[0].onClose)}
+    >
+      {detailsPanel[0].content}
+    </DetailsPanel>
+  );
+}

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineDetailsPanel/CourseOutlineDetailsPanel.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineDetailsPanel/CourseOutlineDetailsPanel.tsx
@@ -4,37 +4,80 @@ import { ActionType, useCourseEditorContext } from '../../../../providers/Course
 import DetailsPanel from '../../../common/DetailsPanel';
 import Icon, { IconType } from '../../../common/Icon';
 import QuizSettingsForm from '../QuizSettingsForm';
+import { DetailsPanelSettingsType } from '../../../../providers/CourseEditorContext/course-editor-context.interface';
 
 export default function CourseOutlineDetailsPanel(): ReactElement {
-  const [state, dispatch] = useCourseEditorContext();
-  const { isDetailsPanelOpen } = state;
+  const [{ course, isDetailsPanelOpen, activeDetailsItem }, dispatch] = useCourseEditorContext();
 
   const onClosePanel = (callback?: () => void) => {
-    dispatch({ type: ActionType.ToggleDetailsPanel });
+    dispatch({ type: ActionType.ToggleDetailsPanel, activeDetailsItem: null });
 
     if (callback) {
       callback();
     }
   };
 
-  const detailsPanel = [
-    {
-      id: 'QuizSettings',
-      iconType: 'QuizSettings',
-      title: 'Quiz Settings',
-      content: <QuizSettingsForm courseId={state.course?.id ?? 0} />,
+  const detailsPanel = {
+    [DetailsPanelSettingsType.Item]: {
+      id: 'Item',
+      iconType: 'ItemSettings',
+      title: 'Item Settings',
+      content: <div>Item</div>,
       onClose: () => console.log('closing'),
     },
-  ];
+    [DetailsPanelSettingsType.Quiz]: {
+      id: 'Quiz',
+      iconType: 'QuizSettings',
+      title: 'Quiz Settings',
+      content: <QuizSettingsForm courseId={course?.id ?? 0} />,
+      onClose: () => console.log('closing'),
+    },
+    [DetailsPanelSettingsType.Question]: {
+      id: 'Question',
+      iconType: 'QuestionSettings',
+      title: 'Question Settings',
+      content: <div>Question</div>,
+      onClose: () => console.log('closing'),
+    },
+    [DetailsPanelSettingsType.QuizWelcome]: {
+      id: 'QuizWelcome',
+      iconType: 'QuizWelcomeSettings',
+      title: 'Quiz Welcome Settings',
+      content: <div>Quiz Welcome Settings</div>,
+      onClose: () => console.log('closing'),
+    },
+    [DetailsPanelSettingsType.QuizFail]: {
+      id: 'QuizFail',
+      iconType: 'QuizFailSettings',
+      title: 'Quiz Fail Settings',
+      content: <div>Quiz Fail Settings</div>,
+      onClose: () => console.log('closing'),
+    },
+    [DetailsPanelSettingsType.QuizSuccess]: {
+      id: 'QuizSuccess',
+      iconType: 'QuizSuccessSettings',
+      title: 'Quiz Success Settings',
+      content: <div>Quiz Success Settings</div>,
+      onClose: () => console.log('closing'),
+    },
+  };
+
+  const activeType = activeDetailsItem?.type ?? null;
 
   return (
-    <DetailsPanel
-      title={detailsPanel[0].title}
-      titleIcon={<Icon type={IconType[detailsPanel[0].iconType as keyof typeof IconType]} />}
-      isOpen={isDetailsPanelOpen}
-      onClose={() => onClosePanel(detailsPanel[0].onClose)}
-    >
-      {detailsPanel[0].content}
-    </DetailsPanel>
+    <>
+      {activeType && (
+        <DetailsPanel
+          title={detailsPanel[activeType].title}
+          titleIcon={
+            <Icon type={IconType[detailsPanel[activeType].iconType as keyof typeof IconType]} />
+          }
+          isOpen={isDetailsPanelOpen}
+          onClose={() => onClosePanel(detailsPanel[activeType].onClose)}
+        >
+          {detailsPanel[activeType].content}
+        </DetailsPanel>
+      )}
+    </>
   );
 }

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineDetailsPanel/CourseOutlineDetailsPanel.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineDetailsPanel/CourseOutlineDetailsPanel.tsx
@@ -10,7 +10,7 @@ export default function CourseOutlineDetailsPanel(): ReactElement {
   const [{ course, isDetailsPanelOpen, activeDetailsItem }, dispatch] = useCourseEditorContext();
 
   const onClosePanel = (callback?: () => void) => {
-    dispatch({ type: ActionType.ToggleDetailsPanel, activeDetailsItem: null });
+    dispatch({ type: ActionType.CloseDetailsPanel });
 
     if (callback) {
       callback();

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineLessonItem/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineLessonItem/index.tsx
@@ -21,12 +21,10 @@ export default function CourseOutlineLessonItem({
   item,
   index,
   className,
-  handleItemClick,
 }: {
   item: INewLesson;
   index: number;
   className: string;
-  handleItemClick: (item: any) => void;
 }): ReactElement {
   const [{ course }, dispatch] = useCourseEditorContext();
 
@@ -75,7 +73,6 @@ export default function CourseOutlineLessonItem({
           }}
           shouldAcceptDrop={shouldAcceptDrop}
           className={cc([{ [classes['is-empty']]: !item.childNodes.toArray().length }])}
-          handleItemClick={(item) => handleItemClick && handleItemClick(item)}
           taskItemProps={{ deletable: true, onDelete: onDeleteTaskItem }}
         />
       </WMCollapse>

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineList/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineList/index.tsx
@@ -72,7 +72,6 @@ export default function CourseOutlineList<T>({
         onDrop={(e) => onDrop(e.addedIndex, e.removedIndex, undefined, e.payload)}
         getChildPayload={(index) => items[index]}
         dragClass={classes['card-ghost']}
-        dragHandleSelector=".drag-handle"
         dropPlaceholder={{
           animationDuration: 150,
           showOnTop: true,

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineList/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineList/index.tsx
@@ -88,7 +88,6 @@ export default function CourseOutlineList<T>({
                   key={item.id}
                   index={i}
                   className={classes['outline-lesson']}
-                  handleItemClick={(lessonItem) => handleItemClick && handleItemClick(lessonItem)}
                 />
               ) : (
                 <TaskItem

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/CourseQuestionList.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/CourseQuestionList.tsx
@@ -31,7 +31,6 @@ export default function CourseQuestionList({
         getChildPayload={(i) => items[i]}
         onDrop={onDrop}
         dragClass={classes['card-ghost']}
-        dragHandleSelector=".drag-handle"
       >
         {items.map((item, i: number) => (
           <DraggableQuestionItem

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/DraggableQuestionItem.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/DraggableQuestionItem.tsx
@@ -6,6 +6,7 @@ import { QuizQuestion } from '../../../../walkme/data/courseBuild/quiz/question'
 
 import { QuizScreenType } from '../QuizEditForm/interface';
 
+import DragHandle from '../../../common/DragHandle/DragHandle';
 import QuestionItem from './QuestionItem';
 
 import classes from './style.module.scss';
@@ -26,16 +27,15 @@ export default function DraggableQuestionItem({
   ...otherProps
 }: IQuestionItem): ReactElement {
   return (
-    <Draggable
-      key={index}
-      className={cc([classes['draggable-question-item'], className])}
-      {...otherProps}
-    >
-      <QuestionItem
-        item={{ ...item, type: QuizScreenType.QuestionScreen }}
-        key={index}
-        onClick={onClick}
-      />
+    <Draggable key={index} {...otherProps}>
+      <div className={cc([classes['draggable-question-item'], className])}>
+        <DragHandle className={classes['question-item-drag-handle']} />
+        <QuestionItem
+          item={{ ...item, type: QuizScreenType.QuestionScreen }}
+          key={index}
+          onClick={onClick}
+        />
+      </div>
     </Draggable>
   );
 }

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/index.tsx
@@ -62,6 +62,7 @@ export default function CourseOutlineQuiz({
     dispatch({
       type: ActionType.ToggleDetailsPanel,
       activeDetailsItem: { type, id: data.id as number },
+      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/index.tsx
@@ -5,12 +5,11 @@ import { QuizScreen } from '@walkme/types';
 import { useCourseEditorContext, ActionType } from '../../../../providers/CourseEditorContext';
 import { Quiz } from '../../../../walkme/data/courseBuild/quiz';
 import { QuizQuestion } from '../../../../walkme/data/courseBuild/quiz/question';
-
+import { DetailsPanelSettingsType } from '../../../../providers/CourseEditorContext/course-editor-context.interface';
 import WMCollapse from '../../../common/WMCollapse';
-
 import { QuizScreenType } from '../QuizEditForm/interface';
-
 import QuizHeader from '../QuizHeader';
+
 import CourseQuestionList from './CourseQuestionList';
 import QuestionItem from './QuestionItem';
 import classes from './style.module.scss';
@@ -51,11 +50,18 @@ export default function CourseOutlineQuiz({
 
   const shouldAcceptDrop = (e: any, payload: any) => !payload.type;
 
-  const onItemClick = ({ type, data }: { type: QuizScreenType; data: any }) => {
+  /*  const onItemClick = ({ type, data }: { type: QuizScreenType; data: any }) => {
     setActiveOutlineItem({ type, id: data.id });
     quizItemClick({
       type,
       data,
+    });
+  }; */
+
+  const onItemClick = ({ type, data }: { type: DetailsPanelSettingsType; data: any }) => {
+    dispatch({
+      type: ActionType.ToggleDetailsPanel,
+      activeDetailsItem: { type, id: data.id as number },
     });
   };
 
@@ -72,7 +78,7 @@ export default function CourseOutlineQuiz({
           { [classes['active-item']]: activeOutlineItem?.type === QuizScreenType.WelcomeScreen },
         ])}
         onClick={() =>
-          onItemClick({ type: QuizScreenType.WelcomeScreen, data: item.welcomeScreen })
+          onItemClick({ type: DetailsPanelSettingsType.QuizWelcome, data: item.welcomeScreen })
         }
       />
       <CourseQuestionList
@@ -93,7 +99,7 @@ export default function CourseOutlineQuiz({
         ])}
         activeQuestionId={activeOutlineItem?.id}
         onQuestionClick={(question: QuizQuestion) =>
-          onItemClick({ type: QuizScreenType.QuestionScreen, data: question })
+          onItemClick({ type: DetailsPanelSettingsType.Question, data: question })
         }
       />
       <QuestionItem
@@ -103,7 +109,7 @@ export default function CourseOutlineQuiz({
           { [classes['active-item']]: activeOutlineItem?.type === QuizScreenType.SuccessScreen },
         ])}
         onClick={() =>
-          onItemClick({ type: QuizScreenType.SuccessScreen, data: item.successScreen })
+          onItemClick({ type: DetailsPanelSettingsType.QuizSuccess, data: item.successScreen })
         }
       />
       <QuestionItem
@@ -112,7 +118,9 @@ export default function CourseOutlineQuiz({
           classes['fail-screen-item'],
           { [classes['active-item']]: activeOutlineItem?.type === QuizScreenType.FailScreen },
         ])}
-        onClick={() => onItemClick({ type: QuizScreenType.FailScreen, data: item.failScreen })}
+        onClick={() =>
+          onItemClick({ type: DetailsPanelSettingsType.QuizFail, data: item.failScreen })
+        }
       />
     </WMCollapse>
   );

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/index.tsx
@@ -60,9 +60,8 @@ export default function CourseOutlineQuiz({
 
   const onItemClick = ({ type, data }: { type: DetailsPanelSettingsType; data: any }) => {
     dispatch({
-      type: ActionType.ToggleDetailsPanel,
+      type: ActionType.OpenDetailsPanel,
       activeDetailsItem: { type, id: data.id as number },
-      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/style.module.scss
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/style.module.scss
@@ -34,20 +34,40 @@
 }
 
 .draggable-question-item {
-  cursor: grab;
+  display: flex;
+  border-bottom: var(--wm-border);
+  background-color: var(--white);
+
+  .question-item {
+    border: none;
+    padding: 0;
+  }
 
   .disabled {
     pointer-events: none;
     opacity: 0.5;
   }
+
+  .question-item-drag-handle {
+    visibility: hidden;
+  }
+
+  &:hover {
+    background-color: var(--hover-color);
+
+    .question-item-drag-handle {
+      visibility: visible;
+    }
+  }
 }
 
 .question-item {
   display: flex;
+  flex: 1;
   align-items: center;
   height: 35px;
   color: var(--neutral800);
-  padding: 0 20px;
+  padding: 0 22px;
   border-bottom: var(--wm-border);
 
   .icon {
@@ -74,7 +94,7 @@
 
 .card-ghost {
   border: 1px solid var(--wm-border);
-  background-color: var(--white);
+  background-color: var(--red);
   box-shadow: var(--drag-shadow);
   cursor: grabbing;
 }

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { useCourseEditorContext } from '../../../providers/CourseEditorContext';
-
-import { SearchFilter } from '../../common/filters';
+import { ActionType, useCourseEditorContext } from '../../../providers/CourseEditorContext';
 
 import CourseOutlineQuiz from './CourseOutlineQuiz';
 import CourseOutlineList from './CourseOutlineList';
@@ -22,6 +20,10 @@ export default function CourseOutlineTab(): ReactElement {
   const [state, dispatch] = useCourseEditorContext();
   const { course, quiz, courseOutlineSearchValue } = state;
 
+  const onItemClick = () => {
+    dispatch({ type: ActionType.ToggleDetailsPanel });
+  };
+
   return (
     <div className={classes['course-outline-tab']}>
       <ActionMenu className={classes['add-btn']} />
@@ -34,7 +36,12 @@ export default function CourseOutlineTab(): ReactElement {
         }}
       /> */}
       {course && (
-        <CourseOutlineList items={course?.items.toArray() ?? []} course={course} hasQuiz={!!quiz} />
+        <CourseOutlineList
+          items={course?.items.toArray() ?? []}
+          course={course}
+          hasQuiz={!!quiz}
+          handleItemClick={onItemClick}
+        />
       )}
       {quiz && (
         <CourseOutlineQuiz

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
@@ -23,7 +23,7 @@ export default function CourseOutlineTab(): ReactElement {
   const { course, quiz, courseOutlineSearchValue } = state;
 
   return (
-    <>
+    <div className={classes['course-outline-tab']}>
       <ActionMenu className={classes['add-btn']} />
       {/* <SearchFilter
         className={classes['search']}
@@ -45,6 +45,6 @@ export default function CourseOutlineTab(): ReactElement {
           }}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
@@ -25,6 +25,7 @@ export default function CourseOutlineTab(): ReactElement {
     dispatch({
       type: ActionType.ToggleDetailsPanel,
       activeDetailsItem: { type: DetailsPanelSettingsType.Item, id: item.id },
+      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
@@ -23,9 +23,8 @@ export default function CourseOutlineTab(): ReactElement {
 
   const onItemClick = (item: any) => {
     dispatch({
-      type: ActionType.ToggleDetailsPanel,
+      type: ActionType.OpenDetailsPanel,
       activeDetailsItem: { type: DetailsPanelSettingsType.Item, id: item.id },
-      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineTab.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import { ActionType, useCourseEditorContext } from '../../../providers/CourseEditorContext';
+import { DetailsPanelSettingsType } from '../../../providers/CourseEditorContext/course-editor-context.interface';
 
 import CourseOutlineQuiz from './CourseOutlineQuiz';
 import CourseOutlineList from './CourseOutlineList';
@@ -20,8 +21,11 @@ export default function CourseOutlineTab(): ReactElement {
   const [state, dispatch] = useCourseEditorContext();
   const { course, quiz, courseOutlineSearchValue } = state;
 
-  const onItemClick = () => {
-    dispatch({ type: ActionType.ToggleDetailsPanel });
+  const onItemClick = (item: any) => {
+    dispatch({
+      type: ActionType.ToggleDetailsPanel,
+      activeDetailsItem: { type: DetailsPanelSettingsType.Item, id: item.id },
+    });
   };
 
   return (

--- a/src/components/Screen/CourseEditorScreen/CourseSettingsTab/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/CourseSettingsTab/index.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import cc from 'classcat';
+
+import { useCourseEditorContext, ActionType } from '../../../../providers/CourseEditorContext';
+
+import FormGroup from '../../../common/FormGroup';
+import WMSwitch from '../../../common/WMSwitch';
+
+import classes from './style.module.scss';
+
+export default function CourseSettingsTab(): ReactElement {
+  const [{ course }, dispatch] = useCourseEditorContext();
+
+  const updateEnableIfPreviousDone = (checked: boolean) => {
+    if (course?.properties) {
+      course.properties.enableIfPreviousDone = checked;
+      dispatch({ type: ActionType.UpdateCourseOutline, updateHasChange: true });
+    }
+  };
+
+  const updateEnforceOrder = (checked: boolean) => {
+    if (course?.properties) {
+      course.properties.enforceOrder = checked;
+      dispatch({ type: ActionType.UpdateCourseOutline, updateHasChange: true });
+    }
+  };
+
+  return (
+    <div className={classes['course-settings-tab']}>
+      {course?.properties && (
+        <>
+          <FormGroup
+            className={cc([classes['segmentation'], classes['course-settings-form-group']])}
+            title="Segmentation"
+          >
+            {/* drodown */}
+            <sub>No segments have been defined in the Editor. Learn More </sub>
+          </FormGroup>
+          <FormGroup
+            className={cc([classes['learning-path'], classes['course-settings-form-group']])}
+            title="Learning Path"
+          >
+            <WMSwitch
+              className={classes['switch-field']}
+              checked={course?.properties.enableIfPreviousDone}
+              label="Allow users to take the course only when previous one is completed"
+              onChange={(checked: boolean) => updateEnableIfPreviousDone(checked)}
+            />
+            <WMSwitch
+              className={classes['switch-field']}
+              checked={course?.properties.enforceOrder}
+              label="Enforce order for course outline"
+              onChange={(checked: boolean) => updateEnforceOrder(checked)}
+            />
+          </FormGroup>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Screen/CourseEditorScreen/CourseSettingsTab/style.module.scss
+++ b/src/components/Screen/CourseEditorScreen/CourseSettingsTab/style.module.scss
@@ -1,0 +1,23 @@
+.course-settings-tab {
+  padding: 0 20px 15px;
+
+  .course-settings-form-group {
+    margin-bottom: 30px;
+  }
+
+  .learning-path {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .switch-field {
+    // display: block;
+    margin: 10px 0 0;
+
+    &.space-bottom {
+      margin-bottom: 10px;
+    }
+  }
+}

--- a/src/components/Screen/CourseEditorScreen/LessonHeader/EditbaleLessonTitle.tsx
+++ b/src/components/Screen/CourseEditorScreen/LessonHeader/EditbaleLessonTitle.tsx
@@ -43,8 +43,12 @@ export default function LessonEditableTitle({ lesson }: { lesson?: any }): React
     dispatch({ type: ActionType.UpdateCourseOutline, updateHasChange: true });
   };
 
+  const toggleLessonSettings = () => {
+    dispatch({ type: ActionType.ToggleDetailsPanel });
+  };
+
   return (
-    <div className={cc([classes['editable-lesson-title']])}>
+    <div className={cc([classes['editable-lesson-title']])} onClick={toggleLessonSettings}>
       <div className={cc([classes['text'], { [classes['hidden']]: showInput }])}>
         <span className={classes['lesson-title-text']}>{lesson?.title ?? ''}</span>
         <WMButton

--- a/src/components/Screen/CourseEditorScreen/LessonHeader/EditbaleLessonTitle.tsx
+++ b/src/components/Screen/CourseEditorScreen/LessonHeader/EditbaleLessonTitle.tsx
@@ -43,12 +43,8 @@ export default function LessonEditableTitle({ lesson }: { lesson?: any }): React
     dispatch({ type: ActionType.UpdateCourseOutline, updateHasChange: true });
   };
 
-  const toggleLessonSettings = () => {
-    dispatch({ type: ActionType.ToggleDetailsPanel });
-  };
-
   return (
-    <div className={cc([classes['editable-lesson-title']])} onClick={toggleLessonSettings}>
+    <div className={cc([classes['editable-lesson-title']])}>
       <div className={cc([classes['text'], { [classes['hidden']]: showInput }])}>
         <span className={classes['lesson-title-text']}>{lesson?.title ?? ''}</span>
         <WMButton

--- a/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
@@ -1,27 +1,31 @@
 import React, { ReactElement } from 'react';
 import cc from 'classcat';
 
+import { ActionType, useCourseEditorContext } from '../../../../providers/CourseEditorContext';
+import { DetailsPanelSettingsType } from '../../../../providers/CourseEditorContext/course-editor-context.interface';
+import WMButton from '../../../common/WMButton';
 import Header from '../../../common/Header';
 import Icon, { IconType } from '../../../common/Icon';
 
-import { ActionType, useCourseEditorContext } from '../../../../providers/CourseEditorContext';
-import WMButton from '../../../common/WMButton';
 import classes from './style.module.scss';
 
 export default function QuizHeader({ className }: { className?: string }): ReactElement {
-  const [{ course, isDetailsPanelOpen }, dispatch] = useCourseEditorContext();
+  const [{ course, quiz, isDetailsPanelOpen }, dispatch] = useCourseEditorContext();
 
   const deleteQuiz = () => {
     course?.deleteQuiz();
     dispatch({ type: ActionType.DeleteQuiz });
 
     if (isDetailsPanelOpen) {
-      dispatch({ type: ActionType.ToggleDetailsPanel });
+      dispatch({ type: ActionType.ToggleDetailsPanel, activeDetailsItem: null });
     }
   };
 
   const toggleSettings = () => {
-    dispatch({ type: ActionType.ToggleDetailsPanel });
+    dispatch({
+      type: ActionType.ToggleDetailsPanel,
+      activeDetailsItem: { type: DetailsPanelSettingsType.Quiz, id: quiz?.id ?? 0 },
+    });
   };
 
   return (

--- a/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
@@ -25,6 +25,7 @@ export default function QuizHeader({ className }: { className?: string }): React
     dispatch({
       type: ActionType.ToggleDetailsPanel,
       activeDetailsItem: { type: DetailsPanelSettingsType.Quiz, id: quiz?.id ?? 0 },
+      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
@@ -17,15 +17,14 @@ export default function QuizHeader({ className }: { className?: string }): React
     dispatch({ type: ActionType.DeleteQuiz });
 
     if (isDetailsPanelOpen) {
-      dispatch({ type: ActionType.ToggleDetailsPanel, activeDetailsItem: null });
+      dispatch({ type: ActionType.CloseDetailsPanel });
     }
   };
 
   const toggleSettings = () => {
     dispatch({
-      type: ActionType.ToggleDetailsPanel,
+      type: ActionType.OpenDetailsPanel,
       activeDetailsItem: { type: DetailsPanelSettingsType.Quiz, id: quiz?.id ?? 0 },
-      openDetailsPanel: true,
     });
   };
 

--- a/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/QuizHeader/index.tsx
@@ -9,15 +9,23 @@ import WMButton from '../../../common/WMButton';
 import classes from './style.module.scss';
 
 export default function QuizHeader({ className }: { className?: string }): ReactElement {
-  const [{ course }, dispatch] = useCourseEditorContext();
+  const [{ course, isDetailsPanelOpen }, dispatch] = useCourseEditorContext();
 
   const deleteQuiz = () => {
     course?.deleteQuiz();
     dispatch({ type: ActionType.DeleteQuiz });
+
+    if (isDetailsPanelOpen) {
+      dispatch({ type: ActionType.ToggleDetailsPanel });
+    }
+  };
+
+  const toggleSettings = () => {
+    dispatch({ type: ActionType.ToggleDetailsPanel });
   };
 
   return (
-    <Header className={cc([classes['quiz-header'], className])}>
+    <Header className={cc([classes['quiz-header'], className])} onClick={toggleSettings}>
       <Icon type={IconType.QuizSettings} />
       <div className={cc([classes['editable-quiz-title']])}>
         <div className={classes['text']}>

--- a/src/components/Screen/CourseEditorScreen/QuizSettingsForm/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/QuizSettingsForm/index.tsx
@@ -1,14 +1,9 @@
-import React, { ReactElement, useState, useEffect, useCallback, ChangeEvent } from 'react';
+import React, { ReactElement, ChangeEvent } from 'react';
 import { Divider } from 'antd';
 import cc from 'classcat';
 import { BuildQuizProperties } from '@walkme/types';
 
-import {
-  useCourseEditorContext,
-  fetchItemsList,
-  fetchCourse,
-  ActionType,
-} from '../../../../providers/CourseEditorContext';
+import { useCourseEditorContext, ActionType } from '../../../../providers/CourseEditorContext';
 
 import WMInput from '../../../common/WMInput';
 import FormGroup from '../../../common/FormGroup';
@@ -19,13 +14,6 @@ import classes from './style.module.scss';
 export default function QuizSettingsForm({ courseId }: { courseId: number }): ReactElement {
   const [state, dispatch] = useCourseEditorContext();
   const { course } = state;
-
-  useEffect(() => {
-    fetchItemsList(dispatch);
-    fetchCourse(dispatch, courseId);
-
-    return () => dispatch({ type: ActionType.ResetCourseEditor });
-  }, [dispatch, courseId]);
 
   const updateQuizProperties = (updatedData: Partial<BuildQuizProperties>) => {
     if (course?.quiz?.properties) {

--- a/src/components/Screen/CourseEditorScreen/TaskItem/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/TaskItem/index.tsx
@@ -7,6 +7,7 @@ import { CourseItemType } from '../../../../interfaces/course.interfaces';
 
 import Icon, { IconType } from '../../../common/Icon';
 import WMButton from '../../../common/WMButton';
+import DragHandle from '../../../common/DragHandle/DragHandle';
 
 import classes from './style.module.scss';
 
@@ -44,12 +45,9 @@ export default function TaskItem({
   };
 
   return (
-    <Draggable
-      key={index}
-      className={cc([classes['task-item'], 'drag-handle', className])}
-      {...otherProps}
-    >
+    <Draggable key={index} className={cc([classes['task-item'], className])} {...otherProps}>
       <div key={index} className={classes['item']} onClick={onClick}>
+        <DragHandle className={classes['task-item-drag-handle']} />
         <Icon type={iconType[type as keyof typeof iconType]} className={classes['icon']} />
         <span className={classes['title']}>{title}</span>
         {deletable && (

--- a/src/components/Screen/CourseEditorScreen/TaskItem/style.module.scss
+++ b/src/components/Screen/CourseEditorScreen/TaskItem/style.module.scss
@@ -1,6 +1,5 @@
 .task-item {
   border-bottom: var(--wm-border);
-  cursor: grab;
 
   &:first-of-type {
     border-top: var(--wm-border);
@@ -11,7 +10,7 @@
     align-items: center;
     height: 35px;
     color: var(--neutral800);
-    padding: 0 20px;
+    padding: 0 20px 0 0;
 
     .icon {
       color: var(--secondary500);
@@ -42,5 +41,14 @@
     .delete-button {
       display: inline-block;
     }
+
+    .task-item-drag-handle {
+      visibility: visible;
+    }
+  }
+
+  .task-item-drag-handle {
+    visibility: hidden;
+    margin-right: 8px;
   }
 }

--- a/src/components/Screen/CourseEditorScreen/style.module.scss
+++ b/src/components/Screen/CourseEditorScreen/style.module.scss
@@ -105,11 +105,6 @@
         :global(.ant-tabs-tabpane) {
           display: flex;
           flex-direction: column;
-          padding: 0 20px 15px;
-
-          &[tabindex='-1'] {
-            display: none;
-          }
         }
       }
 
@@ -160,4 +155,8 @@
   .cancel-button {
     margin-right: 20px;
   }
+}
+
+.course-outline-tab {
+  padding: 0 20px 15px;
 }

--- a/src/components/common/DetailsPanel/style.module.scss
+++ b/src/components/common/DetailsPanel/style.module.scss
@@ -9,10 +9,10 @@
   transition: all 0.3s ease-in-out;
 
   :global(.ant-card-body) {
-    height: 560px;
     padding: 0;
     display: flex;
     flex-direction: column;
+    height: 100%;
 
     > header > * {
       margin-bottom: 0;

--- a/src/components/common/DragHandle/DragHandle.tsx
+++ b/src/components/common/DragHandle/DragHandle.tsx
@@ -1,0 +1,14 @@
+import React, { ReactElement } from 'react';
+import cc from 'classcat';
+
+import { ReactComponent as DragHandleIcon } from '../../common/WMCollapse/dragHandleIcon.svg';
+
+import classes from './style.module.scss';
+
+export default function DragHandle({ className }: { className?: string }): ReactElement {
+  return (
+    <div className={cc([classes['drag-handle'], 'drag-handle', className])}>
+      <DragHandleIcon />
+    </div>
+  );
+}

--- a/src/components/common/DragHandle/style.module.scss
+++ b/src/components/common/DragHandle/style.module.scss
@@ -1,0 +1,8 @@
+.drag-handle {
+  cursor: grab;
+  justify-content: center;
+  align-items: center;
+  width: 21px;
+  padding-left: 3px;
+  display: flex;
+}

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -8,14 +8,16 @@ export default function Header({
   className,
   titleClassName,
   children,
+  ...otherProps
 }: {
   title?: ReactNode;
   className?: string;
   titleClassName?: string;
   children?: ReactNode;
+  [key: string]: any;
 }): ReactElement {
   return (
-    <header className={cc([classes.header, className])}>
+    <header className={cc([classes.header, className])} {...otherProps}>
       {title && <div className={cc([classes.title, titleClassName])}>{title}</div>}
       {children}
     </header>

--- a/src/components/common/WMCollapse/index.tsx
+++ b/src/components/common/WMCollapse/index.tsx
@@ -2,7 +2,8 @@ import React, { ReactNode, ReactElement, useState, useEffect } from 'react';
 import SmoothCollapse from 'react-smooth-collapse';
 import cc from 'classcat';
 
-import { ReactComponent as DragHandleIcon } from './dragHandleIcon.svg';
+import DragHandle from '../DragHandle/DragHandle';
+
 import { ReactComponent as DownArrowIcon } from './down-arrow.svg';
 import classes from './style.module.scss';
 
@@ -40,11 +41,7 @@ export default function WMCollapse({
           headerClassName,
         ])}
       >
-        {hasDragHandle && (
-          <div className={cc([classes['drag-handle'], 'drag-handle'])}>
-            <DragHandleIcon />
-          </div>
-        )}
+        {hasDragHandle && <DragHandle className={classes['collapse-drag-handle']} />}
         <div
           className={cc([classes['collapse-button'], { [classes['is-open']]: open }])}
           onClick={() => setOpen(!open)}

--- a/src/components/common/WMCollapse/index.tsx
+++ b/src/components/common/WMCollapse/index.tsx
@@ -14,7 +14,9 @@ interface IWMCollapse {
   headerClassName?: string;
   isOpen?: boolean;
   hasDragHandle?: boolean;
+  onClick?: (e: any) => void;
   onOpenChange?: (isOpen: boolean) => void;
+  [key: string]: any;
 }
 
 export default function WMCollapse({
@@ -24,6 +26,7 @@ export default function WMCollapse({
   headerClassName,
   isOpen = true,
   hasDragHandle = false,
+  onClick,
   ...otherProps
 }: IWMCollapse): ReactElement {
   const [open, setOpen] = useState(isOpen);
@@ -40,6 +43,7 @@ export default function WMCollapse({
           { [classes['has-drag-handle']]: hasDragHandle },
           headerClassName,
         ])}
+        onClick={onClick}
       >
         {hasDragHandle && <DragHandle className={classes['collapse-drag-handle']} />}
         <div

--- a/src/components/common/WMCollapse/style.module.scss
+++ b/src/components/common/WMCollapse/style.module.scss
@@ -23,25 +23,20 @@
       }
 
       &:hover {
-        .collapse-button {
+        /* .collapse-button {
           margin-right: 10px;
           margin-left: 3px;
-        }
+        } */
 
-        .drag-handle {
-          display: flex;
+        .collapse-drag-handle {
+          visibility: visible;
         }
       }
     }
   }
 
-  .drag-handle {
-    cursor: grab;
-    justify-content: center;
-    align-items: center;
-    width: 21px;
-    padding-left: 3px;
-    display: none;
+  .collapse-drag-handle {
+    visibility: hidden;
   }
 
   .collapse-button {

--- a/src/components/common/WMTabs/index.tsx
+++ b/src/components/common/WMTabs/index.tsx
@@ -11,12 +11,18 @@ export type { IWMTabPanel };
 
 export interface IWMTabs extends TabsProps {
   className?: string;
+  onTabClick?: (activeKey: string, e: React.KeyboardEvent | React.MouseEvent) => void;
   children: ReactNode;
 }
 
-export default function WMTabs({ className, children, ...otherProps }: IWMTabs): ReactElement {
+export default function WMTabs({
+  className,
+  onTabClick,
+  children,
+  ...otherProps
+}: IWMTabs): ReactElement {
   return (
-    <Tabs className={cc([classes['wm-tabs'], className])} {...otherProps}>
+    <Tabs className={cc([classes['wm-tabs'], className])} {...otherProps} onTabClick={onTabClick}>
       {children}
     </Tabs>
   );

--- a/src/providers/CourseEditorContext/actions.ts
+++ b/src/providers/CourseEditorContext/actions.ts
@@ -10,6 +10,7 @@ export enum ActionType {
   DeleteQuiz = 'DELETE_QUIZ',
   UpdateCourseOutline = 'UPDATE_COURSE_OUTLINE',
   SetCourseOutlineSearchValue = 'SET_COURSE_OUTLINE_SEARCH_VALUE',
-  ToggleDetailsPanel = 'TOGGLE_DETAILS_PANEL',
+  OpenDetailsPanel = 'OPEN_DETAILS_PANEL',
+  CloseDetailsPanel = 'CLOSE_DETAILS_PANEL',
   ResetCourseEditor = 'RESET_COURSE_EDITOR',
 }

--- a/src/providers/CourseEditorContext/course-editor-context.interface.ts
+++ b/src/providers/CourseEditorContext/course-editor-context.interface.ts
@@ -25,6 +25,7 @@ export interface IAction {
   courseOutlineSearchValue?: string;
   updateHasChange?: boolean;
   activeDetailsItem?: { type: DetailsPanelSettingsType; id: number } | null;
+  openDetailsPanel?: boolean;
 }
 
 export interface IDispatch {

--- a/src/providers/CourseEditorContext/course-editor-context.interface.ts
+++ b/src/providers/CourseEditorContext/course-editor-context.interface.ts
@@ -24,10 +24,20 @@ export interface IAction {
   courseOutline?: Array<ICourseOutlineItem>;
   courseOutlineSearchValue?: string;
   updateHasChange?: boolean;
+  activeDetailsItem?: { type: DetailsPanelSettingsType; id: number } | null;
 }
 
 export interface IDispatch {
   (action: IAction): void;
+}
+
+export enum DetailsPanelSettingsType {
+  Item = 'item',
+  Quiz = 'quiz',
+  Question = 'question',
+  QuizWelcome = 'welcome',
+  QuizFail = 'fail',
+  QuizSuccess = 'success',
 }
 
 export interface IState {
@@ -46,6 +56,7 @@ export interface IState {
   refreshCourseOutline: boolean;
   courseOutlineSearchValue: string;
   isDetailsPanelOpen: boolean;
+  activeDetailsItem: { type: DetailsPanelSettingsType; id: number } | null;
   hasChanges: boolean;
 }
 

--- a/src/providers/CourseEditorContext/reducer.ts
+++ b/src/providers/CourseEditorContext/reducer.ts
@@ -75,12 +75,13 @@ export const reducer = produce(
           action.courseOutlineSearchValue ?? initialState.courseOutlineSearchValue;
         draft.filteredCourseOutline = action.course?.items ?? initialState.filteredCourseOutline;
         break;
-      case ActionType.ToggleDetailsPanel:
-        draft.isDetailsPanelOpen =
-          action.openDetailsPanel !== undefined
-            ? action.openDetailsPanel
-            : !draft.isDetailsPanelOpen;
+      case ActionType.OpenDetailsPanel:
+        draft.isDetailsPanelOpen = true;
         draft.activeDetailsItem = action.activeDetailsItem ?? null;
+        break;
+      case ActionType.CloseDetailsPanel:
+        draft.isDetailsPanelOpen = false;
+        draft.activeDetailsItem = null;
         break;
       case ActionType.ResetCourseEditor:
         draft = { ...initialState };

--- a/src/providers/CourseEditorContext/reducer.ts
+++ b/src/providers/CourseEditorContext/reducer.ts
@@ -76,7 +76,10 @@ export const reducer = produce(
         draft.filteredCourseOutline = action.course?.items ?? initialState.filteredCourseOutline;
         break;
       case ActionType.ToggleDetailsPanel:
-        draft.isDetailsPanelOpen = !draft.isDetailsPanelOpen;
+        draft.isDetailsPanelOpen =
+          action.openDetailsPanel !== undefined
+            ? action.openDetailsPanel
+            : !draft.isDetailsPanelOpen;
         draft.activeDetailsItem = action.activeDetailsItem ?? null;
         break;
       case ActionType.ResetCourseEditor:

--- a/src/providers/CourseEditorContext/reducer.ts
+++ b/src/providers/CourseEditorContext/reducer.ts
@@ -16,6 +16,7 @@ export const initialState = {
   refreshCourseOutline: false,
   courseOutlineSearchValue: '',
   isDetailsPanelOpen: false,
+  activeDetailsItem: null,
   hasChanges: false,
 } as IState;
 
@@ -76,6 +77,7 @@ export const reducer = produce(
         break;
       case ActionType.ToggleDetailsPanel:
         draft.isDetailsPanelOpen = !draft.isDetailsPanelOpen;
+        draft.activeDetailsItem = action.activeDetailsItem ?? null;
         break;
       case ActionType.ResetCourseEditor:
         draft = { ...initialState };


### PR DESCRIPTION
- Adds `CourseSettingsTab` component (WIP b/c of missing API)
- Adds `DragHandle` and uses it in all draggable items
- Makes all relevant outline items open the right side panel
- Changes settings pane toggle behavior from toggle to open/close