### PR TITLE
`CourseEditor`: Redirect on system change

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,21 +1,11 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "TeachMe",
+  "name": "TeachMe Editor",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "src": "walkme-fav.png",
+      "sizes": "32x32",
+      "type": "image/png"
     }
   ],
   "start_url": ".",

--- a/src/components/Screen/CourseEditorScreen/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/index.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useEffect } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
-import usePrevious from '@react-hook/previous';
+import { useParams } from 'react-router-dom';
 
 import {
   useCourseEditorContext,
@@ -8,8 +7,7 @@ import {
   fetchCourse,
   ActionType,
 } from '../../../providers/CourseEditorContext';
-import { useAppContext } from '../../../providers/AppContext';
-import { COURSES_ROUTE } from '../../../constants/routes';
+import { useRedirectToMain } from '../../../hooks';
 
 import EditableTitle from '../../common/EditableTitle';
 import ScreenHeader from '../../common/ScreenHeader';
@@ -39,13 +37,7 @@ export default function CourseEditorScreen(): ReactElement {
     dispatch({ type: ActionType.UpdateCourseOutline, updateHasChange: true });
   };
 
-  const [{ system }] = useAppContext();
-  const prevSystem = usePrevious(system);
-  const { push } = useHistory();
-
-  useEffect(() => {
-    if (prevSystem && prevSystem.userId !== system.userId) push(COURSES_ROUTE.path);
-  }, [prevSystem, system, push]);
+  useRedirectToMain();
 
   return (
     <>

--- a/src/components/Screen/CourseEditorScreen/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
+import usePrevious from '@react-hook/previous';
 
 import {
   useCourseEditorContext,
@@ -7,6 +8,8 @@ import {
   fetchCourse,
   ActionType,
 } from '../../../providers/CourseEditorContext';
+import { useAppContext } from '../../../providers/AppContext';
+import { COURSES_ROUTE } from '../../../constants/routes';
 
 import EditableTitle from '../../common/EditableTitle';
 import ScreenHeader from '../../common/ScreenHeader';
@@ -35,6 +38,14 @@ export default function CourseEditorScreen(): ReactElement {
 
     dispatch({ type: ActionType.UpdateCourseOutline, updateHasChange: true });
   };
+
+  const [{ system }] = useAppContext();
+  const prevSystem = usePrevious(system);
+  const { push } = useHistory();
+
+  useEffect(() => {
+    if (prevSystem && prevSystem.userId !== system.userId) push(COURSES_ROUTE.path);
+  }, [prevSystem, system, push]);
 
   return (
     <>

--- a/src/components/Screen/CourseScreen/index.tsx
+++ b/src/components/Screen/CourseScreen/index.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement, useEffect } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
-import usePrevious from '@react-hook/previous';
+import { useParams } from 'react-router-dom';
 
 import { IDateRange } from '../../../utils';
-import { COURSES_ROUTE } from '../../../constants/routes';
+import { useRedirectToMain } from '../../../hooks';
 import { useAppContext } from '../../../providers/AppContext';
 import { useCourseContext, fetchCourseData, ActionType } from '../../../providers/CourseContext';
 import { CourseOverviewData } from '../../../walkme/models';
@@ -28,7 +27,6 @@ export default function CourseScreen(): ReactElement {
   const {
     isUpdating,
     environment: { id: envId },
-    system,
   } = appState;
   const [state, dispatch] = useCourseContext();
   const {
@@ -49,12 +47,7 @@ export default function CourseScreen(): ReactElement {
   const onDateRangeChange = (dateRange?: IDateRange) =>
     dispatch({ type: ActionType.SetDateRange, dateRange });
 
-  const prevSystem = usePrevious(system);
-  const { push } = useHistory();
-
-  useEffect(() => {
-    if (prevSystem && prevSystem.userId !== system.userId) push(COURSES_ROUTE.path);
-  }, [prevSystem, system, push]);
+  useRedirectToMain();
 
   return (
     <>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useRedirectToMain';

--- a/src/hooks/useRedirectToMain.ts
+++ b/src/hooks/useRedirectToMain.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import usePrevious from '@react-hook/previous';
+
+import { useAppContext } from '../providers/AppContext';
+import { COURSES_ROUTE } from '../constants/routes';
+
+export const useRedirectToMain = (): void => {
+  const [{ system }] = useAppContext();
+  const prevSystem = usePrevious(system);
+  const { push } = useHistory();
+
+  useEffect(() => {
+    if (prevSystem && prevSystem.userId !== system.userId) push(COURSES_ROUTE.path);
+  }, [prevSystem, system, push]);
+};

--- a/src/providers/CourseEditorContext/utils.ts
+++ b/src/providers/CourseEditorContext/utils.ts
@@ -36,7 +36,7 @@ export const fetchItemsList = async (dispatch: IDispatch, envId = 0): Promise<vo
   dispatch({ type: ActionType.FetchItems });
 
   try {
-    const courseItems = await getFlatItemsList(envId);
+    const courseItems = await getFlatItemsList(envId, true);
 
     dispatch({ type: ActionType.FetchItemsSuccess, courseItems });
   } catch (error) {


### PR DESCRIPTION
- Redirect to courses screen on system change.
- Add `useRedirectToMain` hook.
- Fix manifest.json warning (and updated site info).
- Update `fetchItemsList` to fetch fresh data from server instead of cached.