### PR TITLE
Link to support

### DIFF
--- a/src/components/Layout/HeaderToolbar/index.tsx
+++ b/src/components/Layout/HeaderToolbar/index.tsx
@@ -40,7 +40,7 @@ export default function HeaderToolbar(): ReactElement {
             <Tooltip title="Help">
               <WMButton
                 className={classes['help-btn']}
-                href="https://walkme.com"
+                href="https://support.walkme.com/knowledge-base/teachme"
                 target="_blank"
                 icon={<Icon type={IconType.HelpCircle} />}
               />

--- a/src/components/Screen/UsersScreen/LoadMoreWrapper.tsx
+++ b/src/components/Screen/UsersScreen/LoadMoreWrapper.tsx
@@ -30,7 +30,7 @@ export default function LoadMoreWrapper(): ReactElement {
 
   return (
     <>
-      {total_rows > defaultQueryOptions.num_of_records && !isFetchingUsers && (
+      {total_rows > users.length && !isFetchingUsers && (
         <div className={classes['load-more-wrapper']}>
           <span>{`1-${users.length} of ${total_rows} results`}</span>
           <LoadMoreButton onClick={() => fetchUsers(dispatch, envId, from, to, options, users)} />

--- a/src/providers/UsersContext/utils.ts
+++ b/src/providers/UsersContext/utils.ts
@@ -38,7 +38,7 @@ export const useUsersContext = (): [IState, IDispatch] => [useUsersState(), useU
 
 export const defaultQueryOptions = {
   first_item_index: 0,
-  num_of_records: 10,
+  num_of_records: 50,
   sort_by: UsersColumn.ID,
   sort_by_order: UsersOrder.ASC,
   user_name: '',


### PR DESCRIPTION
- Updates 'help' link to walkme support page.
- `UsersScreen` table: Fetching 50 rows instead of 10.
- `UsersScreen`: Hides 'Load more' button if all available rows are fetched.