### PR TITLE
`fetchItemsList()` to only pass 'refresh' option when refreshing the items list

### DIFF
--- a/src/components/Screen/CourseEditorScreen/ResourcesList.tsx
+++ b/src/components/Screen/CourseEditorScreen/ResourcesList.tsx
@@ -18,7 +18,12 @@ import ResourcesListEmptyState from './ResourcesListEmptyState';
 import classes from './style.module.scss';
 
 export default function ResourcesList(): ReactElement {
-  const [{ isUpdating }] = useAppContext();
+  const [
+    {
+      isUpdating,
+      environment: { id: envId },
+    },
+  ] = useAppContext();
   const [state, dispatch] = useCourseEditorContext();
   const { isFetchingItems, courseItems, filteredCourseItems, courseItemsSearchValue } = state;
 
@@ -35,7 +40,7 @@ export default function ResourcesList(): ReactElement {
   };
 
   const onRefresh = async () => {
-    await fetchItemsList(dispatch);
+    await fetchItemsList(dispatch, envId, { refresh: true });
     onSearch(courseItemsSearchValue);
   };
 

--- a/src/components/Screen/CourseEditorScreen/ResourcesList.tsx
+++ b/src/components/Screen/CourseEditorScreen/ResourcesList.tsx
@@ -50,7 +50,7 @@ export default function ResourcesList(): ReactElement {
       title={
         <div className={classes['title']}>
           <span>Items</span>
-          <RefreshButton onClick={onRefresh} />
+          <RefreshButton onClick={onRefresh} loading={isFetchingItems} />
         </div>
       }
     >

--- a/src/components/Screen/CourseEditorScreen/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/index.tsx
@@ -25,7 +25,7 @@ export default function CourseEditorScreen(): ReactElement {
   const history = useHistory();
 
   useEffect(() => {
-    fetchItemsList(dispatch);
+    fetchItemsList(dispatch, environment.id);
     fetchCourse(dispatch, courseId, environment.id, history);
 
     return () => dispatch({ type: ActionType.ResetCourseEditor });

--- a/src/components/Screen/Playground/components/CourseItemDetailsPanel.tsx
+++ b/src/components/Screen/Playground/components/CourseItemDetailsPanel.tsx
@@ -35,7 +35,7 @@ export default function CourseItemDetailsPanel(): ReactElement {
   };
 
   useEffect(() => {
-    fetchItemsList(dispatch);
+    fetchItemsList(dispatch, environment.id);
     fetchCourse(dispatch, courseId, environment.id, history);
 
     return () => dispatch({ type: ActionType.ResetCourseEditor });

--- a/src/components/Screen/Playground/components/QuizEdit.tsx
+++ b/src/components/Screen/Playground/components/QuizEdit.tsx
@@ -28,7 +28,7 @@ export default function QuizEdit(): ReactElement {
   const [quizScreenData] = useState<QuizScreen | QuizQuestion>();
 
   useEffect(() => {
-    fetchItemsList(dispatch);
+    fetchItemsList(dispatch, environment.id);
     fetchCourse(dispatch, courseId, environment.id, history);
 
     return () => dispatch({ type: ActionType.ResetCourseEditor });

--- a/src/components/common/buttons/RefreshButton/index.tsx
+++ b/src/components/common/buttons/RefreshButton/index.tsx
@@ -9,15 +9,18 @@ import classes from './style.module.scss';
 export default function RefreshButton({
   className,
   onClick,
+  loading,
 }: {
   className?: string;
   onClick: () => void;
+  loading?: boolean;
 }): ReactElement {
   return (
     <WMButton
       className={cc([classes['refresh-button'], className])}
       onClick={onClick}
       icon={<Icon type={IconType.Refresh} />}
+      loading={loading}
     />
   );
 }

--- a/src/components/common/buttons/RefreshButton/style.module.scss
+++ b/src/components/common/buttons/RefreshButton/style.module.scss
@@ -1,4 +1,8 @@
 .refresh-button:global(.ant-btn) {
   font-size: 16px;
   background-color: transparent;
+
+  &:global(.ant-btn-loading) {
+    background-color: transparent;
+  }
 }

--- a/src/providers/CourseEditorContext/utils.ts
+++ b/src/providers/CourseEditorContext/utils.ts
@@ -37,7 +37,7 @@ export const useCourseEditorContext = (): [IState, IDispatch] => [
 
 export const fetchItemsList = async (
   dispatch: IDispatch,
-  envId = 0,
+  envId: number,
   options?: { refresh?: boolean },
 ): Promise<void> => {
   dispatch({ type: ActionType.FetchItems });
@@ -55,7 +55,7 @@ export const fetchItemsList = async (
 export const fetchCourse = async (
   dispatch: IDispatch,
   courseId: string | number | undefined,
-  envId = 0,
+  envId: number,
   history: History,
 ): Promise<void> => {
   dispatch({ type: ActionType.FetchCourse });

--- a/src/providers/CourseEditorContext/utils.ts
+++ b/src/providers/CourseEditorContext/utils.ts
@@ -35,11 +35,15 @@ export const useCourseEditorContext = (): [IState, IDispatch] => [
   useCourseEditorDispatch(),
 ];
 
-export const fetchItemsList = async (dispatch: IDispatch, envId = 0): Promise<void> => {
+export const fetchItemsList = async (
+  dispatch: IDispatch,
+  envId = 0,
+  options?: { refresh?: boolean },
+): Promise<void> => {
   dispatch({ type: ActionType.FetchItems });
 
   try {
-    const courseItems = await getFlatItemsList(envId, true);
+    const courseItems = await getFlatItemsList(envId, options?.refresh);
 
     dispatch({ type: ActionType.FetchItemsSuccess, courseItems });
   } catch (error) {

--- a/src/providers/CoursesContext/utils.ts
+++ b/src/providers/CoursesContext/utils.ts
@@ -84,7 +84,7 @@ export const sortTable = async (
 
 export const exportCourses = async (
   dispatch: IDispatch,
-  envId = 0,
+  envId: number,
   from: string,
   to: string,
 ): Promise<void> => {
@@ -129,7 +129,7 @@ const envNames = {
 
 export const publishCourses = async (
   dispatch: IDispatch,
-  envId = 0,
+  envId: number,
   courses: Array<UICourse>,
 ): Promise<void> => {
   dispatch({ type: ActionType.PublishCourses });
@@ -153,7 +153,7 @@ export const publishCourses = async (
 
 export const archiveCourses = async (
   dispatch: IDispatch,
-  envId = 0,
+  envId: number,
   courses: Array<UICourse>,
 ): Promise<void> => {
   dispatch({ type: ActionType.ArchiveCourses });


### PR DESCRIPTION
- Makes `fetchItemsList` only pass the 'refresh' option when refreshing the list
- Makes `RefreshButton` show loader when refreshing item list
- Replaces all optional `envId`s arguments to required ones