### PR TITLE
Fixes error page crashing

### DIFF
--- a/src/components/Screen/ErrorScreen/index.tsx
+++ b/src/components/Screen/ErrorScreen/index.tsx
@@ -4,10 +4,22 @@ import Icon, { IconType } from '../../common/Icon';
 
 import classes from './style.module.scss';
 
+const getErrorMessage = (error: any) => {
+  if (error) {
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error.message === 'string') {
+      return error.message;
+    }
+  }
+
+  return 'Something went wrong';
+};
+
 export default function ErrorScreen({ error }: { error?: string }): ReactElement {
-  const [errorMessage, setErrorMessage] = useState(
-    error && Boolean(error) ? error : 'Something went wrong',
-  );
+  const errorMessage = getErrorMessage(error);
 
   return (
     <div className={classes['error-screen']}>


### PR DESCRIPTION
Error page was crashing instead of showing the error because the error was an object and not a string.
To reproduce the problem try running the app without the browser extension (You might have to also try and load the app for the first time after logging in).
