### PR TITLE
Redirect to main page on errors when navigating to course page 

### DIFF
--- a/src/components/Screen/CourseScreen/index.tsx
+++ b/src/components/Screen/CourseScreen/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useEffect, useRef } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 
-import { IDateRange, wmMessage, MessageType } from '../../../utils';
+import { IDateRange } from '../../../utils';
 import { useRedirectToMain } from '../../../hooks';
 import { useAppContext, ActionType as AppActionType } from '../../../providers/AppContext';
 import { useCourseContext, fetchCourseData, ActionType } from '../../../providers/CourseContext';
@@ -20,7 +20,6 @@ import {
 } from './courseScreen.interface';
 
 import classes from './style.module.scss';
-import { COURSES_ROUTE } from '../../../constants/routes';
 
 export { parseCourseOutline };
 export type { ICourseOutlineItem, ICourseOutlineLesson, ICourseOutlineItems, ICourseOutline };
@@ -46,14 +45,7 @@ export default function CourseScreen(): ReactElement {
   }, []);
 
   useEffect(() => {
-    (async () => {
-      try {
-        if (!isUpdating) await fetchCourseData(dispatch, courseId, envId, from, to);
-      } catch (error) {
-        wmMessage(error.message, MessageType.Error);
-        history.replace(`${COURSES_ROUTE.path}`);
-      }
-    })();
+    if (!isUpdating) fetchCourseData(dispatch, courseId, envId, from, to, history);
   }, [dispatch, isUpdating, courseId, envId, from, to]);
 
   // Unmount only

--- a/src/components/Screen/CourseScreen/index.tsx
+++ b/src/components/Screen/CourseScreen/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 
-import { IDateRange } from '../../../utils';
+import { IDateRange, wmMessage, MessageType } from '../../../utils';
 import { useRedirectToMain } from '../../../hooks';
 import { useAppContext, ActionType as AppActionType } from '../../../providers/AppContext';
 import { useCourseContext, fetchCourseData, ActionType } from '../../../providers/CourseContext';
@@ -20,6 +20,7 @@ import {
 } from './courseScreen.interface';
 
 import classes from './style.module.scss';
+import { COURSES_ROUTE } from '../../../constants/routes';
 
 export { parseCourseOutline };
 export type { ICourseOutlineItem, ICourseOutlineLesson, ICourseOutlineItems, ICourseOutline };
@@ -37,6 +38,7 @@ export default function CourseScreen(): ReactElement {
   const { courseId } = useParams();
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const history = useHistory();
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -44,7 +46,14 @@ export default function CourseScreen(): ReactElement {
   }, []);
 
   useEffect(() => {
-    if (!isUpdating) fetchCourseData(dispatch, courseId, envId, from, to);
+    (async () => {
+      try {
+        if (!isUpdating) await fetchCourseData(dispatch, courseId, envId, from, to);
+      } catch (error) {
+        wmMessage(error.message, MessageType.Error);
+        history.replace(`${COURSES_ROUTE.path}`);
+      }
+    })();
   }, [dispatch, isUpdating, courseId, envId, from, to]);
 
   // Unmount only

--- a/src/providers/CourseContext/utils.ts
+++ b/src/providers/CourseContext/utils.ts
@@ -7,6 +7,7 @@ import { getCourseOutline } from '../../walkme/data/courseOutline';
 import { getCourseMetadata } from '../../walkme/data/courseMetadata';
 
 import { ActionType, IState, IDispatch } from './course-context.interface';
+import { CourseNotFoundError, TypeNotSupportedError } from '../../walkme/models';
 
 export const CourseStateContext = createContext<IState | undefined>(undefined);
 export const CourseDispatchContext = createContext<IDispatch | undefined>(undefined);
@@ -67,6 +68,8 @@ export const fetchCourseData = async (
   } catch (error) {
     console.error(error);
     dispatch({ type: ActionType.FetchCourseDataError });
+    const errorMessage = getCourseErrorMessage(error, courseId);
+    throw new Error(errorMessage);
   }
 };
 
@@ -90,3 +93,14 @@ export const exportCourse = async (
     wmMessage('Export failed', MessageType.Error);
   }
 };
+
+function getCourseErrorMessage(error: Error, courseId: number): string {
+  switch (true) {
+    case error instanceof CourseNotFoundError:
+      return `Cannot find course with id ${courseId}`;
+    case error instanceof TypeNotSupportedError:
+      return `This course contains unsupported items`;
+    default:
+      return 'Unable to get course';
+  }
+}

--- a/src/providers/CourseContext/utils.ts
+++ b/src/providers/CourseContext/utils.ts
@@ -9,6 +9,9 @@ import { getCourseMetadata } from '../../walkme/data/courseMetadata';
 import { ActionType, IState, IDispatch } from './course-context.interface';
 import { CourseNotFoundError, TypeNotSupportedError } from '../../walkme/models';
 
+import { History } from 'history';
+import { COURSES_ROUTE } from '../../constants/routes';
+
 export const CourseStateContext = createContext<IState | undefined>(undefined);
 export const CourseDispatchContext = createContext<IDispatch | undefined>(undefined);
 
@@ -40,6 +43,7 @@ export const fetchCourseData = async (
   envId: number,
   from: string,
   to: string,
+  history: History,
 ): Promise<void> => {
   dispatch({ type: ActionType.FetchCourseData });
   const id = +courseId;
@@ -69,7 +73,8 @@ export const fetchCourseData = async (
     console.error(error);
     dispatch({ type: ActionType.FetchCourseDataError });
     const errorMessage = getCourseErrorMessage(error, courseId);
-    throw new Error(errorMessage);
+    wmMessage(errorMessage, MessageType.Error);
+    history.replace(`${COURSES_ROUTE.path}`);
   }
 };
 

--- a/src/providers/CourseEditorContext/utils.ts
+++ b/src/providers/CourseEditorContext/utils.ts
@@ -72,7 +72,7 @@ export const fetchCourse = async (
     }
   } catch (error) {
     console.error(error);
-    message.error(`Course '${courseId}' not found`);
+    message.error(`Cannot find course with id ${courseId}`);
     history.push(COURSES_ROUTE.path);
     dispatch({ type: ActionType.FetchCourseError });
   }

--- a/src/walkme/data/courseMetadata.ts
+++ b/src/walkme/data/courseMetadata.ts
@@ -1,7 +1,7 @@
 import * as wm from '@walkme/types';
 import { getCourseSegments } from './services/segments';
 import { TypeName, WalkMeDataCourse } from '@walkme/types';
-import { CourseMetadata, PublishStatus } from '../models';
+import { CourseMetadata, PublishStatus, CourseNotFoundError } from '../models';
 import { getData } from './services/wmData';
 
 export type { CourseMetadata };
@@ -31,6 +31,8 @@ async function getCourse(
   if (typeof courseOrId !== 'number') return courseOrId;
 
   const [course] = await getData(TypeName.Course, environmentId, [courseOrId]);
+  if (!course) throw new CourseNotFoundError(`Unable to find course with id: ${courseOrId}`);
+
   return course as WalkMeDataCourse;
 }
 

--- a/src/walkme/data/services/wmData.ts
+++ b/src/walkme/data/services/wmData.ts
@@ -1,6 +1,7 @@
-import { WalkMeDataItem, TypeName } from '@walkme/types';
+import { WalkMeDataItem, TypeName, TypeId } from '@walkme/types';
 import walkme from '@walkme/editor-sdk';
 import { getTypeId } from './item';
+import { TypeNotSupportedError } from '../../models';
 
 let data: { [key in TypeName]?: Promise<Array<WalkMeDataItem>> } = {};
 let syncData: { [type: number]: Array<WalkMeDataItem> } = {};
@@ -20,9 +21,14 @@ export async function getData(
 }
 
 export function getDataSync(type: number, ids?: Array<number>): Array<WalkMeDataItem> {
+  if (type == TypeId.Walkthru) {
+    throw new TypeNotSupportedError(`TeachMe does not support type ${type}`);
+  }
   const items = syncData[type];
   if (!items) {
-    throw `unable to get data synchronously - call getData first to get it in a sync manner`;
+    throw new Error(
+      `unable to get data synchronously - call getData first to get it in a sync manner`,
+    );
   }
   return filter(items, ids);
 }

--- a/src/walkme/models/course/index.ts
+++ b/src/walkme/models/course/index.ts
@@ -20,3 +20,9 @@ export class CourseNotFoundError extends Error {
     super(message);
   }
 }
+
+export class TypeNotSupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}


### PR DESCRIPTION
When opening a course with an old unsupported walkthru, an error message will appear and redirect to main page.
When navigating directly to course/123 or other non-existing course id an error message will appear and redirect to main page.
 