### PR TITLE
Default env for actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teachme-editor",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "homepage": "https://cdn.walkme.com/apps/teachme-admin",
   "scripts": {

--- a/src/components/Layout/HeaderToolbar/EnvironmentMenu.tsx
+++ b/src/components/Layout/HeaderToolbar/EnvironmentMenu.tsx
@@ -1,24 +1,21 @@
 import React, { ReactElement, useState, useEffect } from 'react';
-import { WalkMeEnvironment } from '@walkme/editor-sdk';
 import { DownOutlined } from '@ant-design/icons';
 import { message } from 'antd';
 
 import { useAppContext, setAppEnvironment } from '../../../providers/AppContext';
-import { getEnvironments } from '../../../walkme';
 
 import WMDropdown, { IWMDropdownOption } from '../../common/WMDropdown';
 import WMButton from '../../common/WMButton';
 
-import { parseEnvironments } from './utils';
+import { getParsedEnvironment } from './utils';
 
 import classes from './style.module.scss';
 
 export default function EnvironmentMenu({ className }: { className?: string }): ReactElement {
-  const [{ environment }, dispatch] = useAppContext();
+  const [{ environment, environments, parsedEnvironments }, dispatch] = useAppContext();
 
   const [selectedEnv, setSelectedEnv] = useState<IWMDropdownOption>();
-  const [environments, setEnvironments] = useState<WalkMeEnvironment[]>([]);
-  const [options, setOptions] = useState<IWMDropdownOption[]>([]);
+  const [options, setOptions] = useState<IWMDropdownOption[]>(parsedEnvironments);
 
   const handleMenuClick = (selected: IWMDropdownOption) => {
     setAppEnvironment({
@@ -31,26 +28,13 @@ export default function EnvironmentMenu({ className }: { className?: string }): 
     message.info(`Environment changed to ${selected.value}`);
   };
 
-  const getEnvironmentsOptions = async () => {
-    const environmentsOptions = await getEnvironments();
-    const options = parseEnvironments(environmentsOptions);
-
-    setEnvironments(environmentsOptions);
-    setOptions(options as IWMDropdownOption[]);
-  };
-
   useEffect(() => {
-    getEnvironmentsOptions();
-
-    return () => {
-      setEnvironments([]);
-      setOptions([]);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (environment?.id) setSelectedEnv(parseEnvironments([environment]) as IWMDropdownOption);
+    if (environment?.id) setSelectedEnv(getParsedEnvironment(environment));
   }, [environment, environment.id]);
+
+  useEffect(() => {
+    setOptions(parsedEnvironments);
+  }, [parsedEnvironments, setOptions]);
 
   return (
     <WMDropdown

--- a/src/components/Layout/HeaderToolbar/utils.ts
+++ b/src/components/Layout/HeaderToolbar/utils.ts
@@ -7,10 +7,12 @@ function getOptions(options: any[]): IWMDropdownOption | IWMDropdownOption[] {
   return options.length > 1 ? options : options[0];
 }
 
-export function parseEnvironments(
-  environments: WalkMeEnvironment[],
-): IWMDropdownOption | IWMDropdownOption[] {
-  return getOptions(environments.map(({ id, name }) => ({ id, value: name })));
+export function parseEnvironments(environments: WalkMeEnvironment[]): IWMDropdownOption[] {
+  return environments.map(({ id, name }) => ({ id, value: name }));
+}
+
+export function getParsedEnvironment(env: WalkMeEnvironment): IWMDropdownOption {
+  return { id: env.id, value: env.name };
 }
 
 export function parseSystems(systems: SystemData[]): IWMDropdownOption | IWMDropdownOption[] {

--- a/src/components/Screen/CoursesScreen/ProductionStatusActions.tsx
+++ b/src/components/Screen/CoursesScreen/ProductionStatusActions.tsx
@@ -18,6 +18,7 @@ export default function ProductionStatusActions(): ReactElement {
   const [appState] = useAppContext();
   const {
     dateRange: { from, to },
+    environment: { id: currentEnvId },
   } = appState;
   const [{ selectedRows, isPublishingCourses, isArchivingCourses }, dispatch] = useCoursesContext();
 
@@ -55,11 +56,11 @@ export default function ProductionStatusActions(): ReactElement {
         coursesCount={selectedRows.length}
         open={showPublish}
         onCancel={() => setShowPublish(false)}
-        onConfirm={async (envId) => {
+        onConfirm={async ({ envId, envName }: { envId: number; envName: string }) => {
           dispatch({ type: ActionType.PublishCourses });
-          await publishCourses(dispatch, envId, selectedRows);
+          await publishCourses(dispatch, envId, envName, selectedRows);
           setShowPublish(false);
-          fetchCoursesData(dispatch, envId, from, to);
+          fetchCoursesData(dispatch, currentEnvId, from, to);
         }}
         isInProgess={isPublishingCourses}
       />
@@ -67,11 +68,11 @@ export default function ProductionStatusActions(): ReactElement {
         coursesCount={selectedRows.length}
         open={showArchive}
         onCancel={() => setShowArchive(false)}
-        onConfirm={async (envId) => {
+        onConfirm={async ({ envId, envName }: { envId: number; envName: string }) => {
           dispatch({ type: ActionType.ArchiveCourses });
-          await archiveCourses(dispatch, envId, selectedRows);
+          await archiveCourses(dispatch, envId, envName, selectedRows);
           setShowArchive(false);
-          fetchCoursesData(dispatch, envId, from, to);
+          fetchCoursesData(dispatch, currentEnvId, from, to);
         }}
         isInProgess={isArchivingCourses}
       />

--- a/src/components/common/WMDialog/style.module.scss
+++ b/src/components/common/WMDialog/style.module.scss
@@ -45,6 +45,9 @@
   :global(.ant-modal-footer) {
     padding: 18px 24px 24px 24px;
     border: none;
+    display: flex;
+    justify-content: flex-end;
+    overflow: hidden;
   }
 
   &.disable-close-button :global(.ant-modal-close) {

--- a/src/components/common/dialogs/ArchiveFromEnvironmentDialog/index.tsx
+++ b/src/components/common/dialogs/ArchiveFromEnvironmentDialog/index.tsx
@@ -41,11 +41,12 @@ export default function ArchiveFromEnvironmentDialog({
           />
         </div>
       }
+      confirmClass={classes['confirmation-button']}
       confirmLabel={`Archive from ${environment?.value}`}
-      onCancel={onCancel}
       onConfirm={() =>
         onConfirm({ envId: environment.id, envName: environment.label ?? environment.value })
       }
+      onCancel={onCancel}
       loadingConfirmButton={isInProgess}
       disableDialog={isInProgess}
     >

--- a/src/components/common/dialogs/ArchiveFromEnvironmentDialog/index.tsx
+++ b/src/components/common/dialogs/ArchiveFromEnvironmentDialog/index.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement, useState } from 'react';
 
-import { EnvironmentType } from '../../../../interfaces/app.interfaces';
 import { pluralizer } from '../../../../utils';
+import { useAppContext } from '../../../../providers/AppContext';
+import { EnvironmentType } from '../../../../interfaces/app.interfaces';
 import WMConfirmationDialog, { IWMConfirmationDialogWrapper } from '../../WMConfirmationDialog';
 import { IWMDropdownOption } from '../../WMDropdown';
 import EnvironmentDropdown from '../DialogEnvironmentDropdown/EnvironmentDropdown';
@@ -9,12 +10,7 @@ import EnvironmentDropdown from '../DialogEnvironmentDropdown/EnvironmentDropdow
 import { ReactComponent as VIcon } from './v.svg';
 import classes from './style.module.scss';
 
-const environments: IWMDropdownOption[] = [
-  { id: EnvironmentType.Production, value: 'Production' },
-  { id: EnvironmentType.Test, value: 'Test' },
-];
-
-export interface IPublishToEnvironmentDialog extends IWMConfirmationDialogWrapper {
+export interface IArchiveFromEnvironmentDialog extends IWMConfirmationDialogWrapper {
   coursesCount: number;
   isInProgess?: boolean;
 }
@@ -25,8 +21,11 @@ export default function ArchiveFromEnvironmentDialog({
   onCancel,
   onConfirm,
   isInProgess,
-}: IPublishToEnvironmentDialog): ReactElement {
-  const [environment, setEnvironment] = useState<IWMDropdownOption>(environments[0]);
+}: IArchiveFromEnvironmentDialog): ReactElement {
+  const [{ parsedEnvironments }] = useAppContext();
+  const [environment, setEnvironment] = useState<IWMDropdownOption>(
+    parsedEnvironments.find((env) => env.id === EnvironmentType.Test) ?? parsedEnvironments[0],
+  );
 
   return (
     <WMConfirmationDialog
@@ -35,16 +34,18 @@ export default function ArchiveFromEnvironmentDialog({
         <div className={classes['archive-dialog-title']}>
           <div>Archive from </div>
           <EnvironmentDropdown
-            environments={environments}
+            environments={parsedEnvironments}
             initialSelectedEnvironment={environment}
             onChange={(selected) => setEnvironment(selected)}
             disabled={isInProgess}
           />
         </div>
       }
-      confirmLabel={`Archive from ${environment.value}`}
+      confirmLabel={`Archive from ${environment?.value}`}
       onCancel={onCancel}
-      onConfirm={() => onConfirm(environment.id)}
+      onConfirm={() =>
+        onConfirm({ envId: environment.id, envName: environment.label ?? environment.value })
+      }
       loadingConfirmButton={isInProgess}
       disableDialog={isInProgess}
     >

--- a/src/components/common/dialogs/ArchiveFromEnvironmentDialog/style.module.scss
+++ b/src/components/common/dialogs/ArchiveFromEnvironmentDialog/style.module.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/mixins';
+
 .archive-dialog-title {
   display: flex;
   align-items: baseline;
@@ -15,5 +17,13 @@ ul.archive-dialog-ul {
     svg {
       margin-right: 5px;
     }
+  }
+}
+
+.confirmation-button {
+  max-width: 240px;
+
+  > span:last-child {
+    @include ellipsis();
   }
 }

--- a/src/components/common/dialogs/DialogEnvironmentDropdown/EnvironmentDropdown.tsx
+++ b/src/components/common/dialogs/DialogEnvironmentDropdown/EnvironmentDropdown.tsx
@@ -15,11 +15,13 @@ export default function EnvironmentDropdown({
 }: {
   className?: string;
   onChange: (selected: IWMDropdownOption) => void;
-  initialSelectedEnvironment: IWMDropdownOption;
+  initialSelectedEnvironment?: IWMDropdownOption;
   environments: IWMDropdownOption[];
   disabled?: boolean;
 }): ReactElement {
-  const [selectedEnvironment, setSelectedEnvironment] = useState(initialSelectedEnvironment);
+  const [selectedEnvironment, setSelectedEnvironment] = useState(
+    initialSelectedEnvironment ?? environments[0],
+  );
 
   const handleMenuClick = (selected: IWMDropdownOption) => {
     setSelectedEnvironment(selected);

--- a/src/components/common/dialogs/ImpersonateDialog/index.tsx
+++ b/src/components/common/dialogs/ImpersonateDialog/index.tsx
@@ -57,6 +57,7 @@ export default function ImpersonateDialog({
       onConfirm={() => onConfirmHandle(localValue)}
       disableConfirmButton={invalid}
       confirmLabel="impersonate"
+      className={classes['impersonate-dialog']}
     >
       <AutoComplete
         className={classes['autocomplete-input']}

--- a/src/components/common/dialogs/ImpersonateDialog/style.module.scss
+++ b/src/components/common/dialogs/ImpersonateDialog/style.module.scss
@@ -1,4 +1,5 @@
-.autocomplete-input {
+.impersonate-dialog {
+  .autocomplete-input {
   width: 100%;
   color: var(--neutral900);
   font-family: var(--font-primary);
@@ -13,9 +14,13 @@
   }
 }
 
-:global(.ant-modal-content) {
-  :global(.ant-btn) {
-    font-size: 10px;
-    margin-left: 20px;
+  :global(.ant-modal-content) {
+    :global(.ant-btn) {
+      font-size: 10px;
+
+      &:not(:first-of-type) {
+        margin-left: 20px;
+      }
+    }
   }
 }

--- a/src/components/common/dialogs/PublishToEnvironmentDialog/index.tsx
+++ b/src/components/common/dialogs/PublishToEnvironmentDialog/index.tsx
@@ -1,18 +1,14 @@
 import React, { ReactElement, useState } from 'react';
 
-import { EnvironmentType } from '../../../../interfaces/app.interfaces';
 import { pluralizer } from '../../../../utils';
+import { useAppContext } from '../../../../providers/AppContext';
+import { EnvironmentType } from '../../../../interfaces/app.interfaces';
 import WMConfirmationDialog, { IWMConfirmationDialogWrapper } from '../../WMConfirmationDialog';
 import { IWMDropdownOption } from '../../WMDropdown';
 import EnvironmentDropdown from '../DialogEnvironmentDropdown/EnvironmentDropdown';
 
 import { ReactComponent as VIcon } from './v.svg';
 import classes from './style.module.scss';
-
-const environments: IWMDropdownOption[] = [
-  { id: EnvironmentType.Production, value: 'Production' },
-  { id: EnvironmentType.Test, value: 'Test' },
-];
 
 export interface IPublishToEnvironmentDialog extends IWMConfirmationDialogWrapper {
   coursesCount: number;
@@ -26,7 +22,10 @@ export default function PublishToEnvironmentDialog({
   onConfirm,
   isInProgess,
 }: IPublishToEnvironmentDialog): ReactElement {
-  const [environment, setEnvironment] = useState<IWMDropdownOption>(environments[0]);
+  const [{ parsedEnvironments }] = useAppContext();
+  const [environment, setEnvironment] = useState<IWMDropdownOption>(
+    parsedEnvironments.find((env) => env.id === EnvironmentType.Test) ?? parsedEnvironments[0],
+  );
 
   return (
     <WMConfirmationDialog
@@ -35,7 +34,7 @@ export default function PublishToEnvironmentDialog({
         <div className={classes['publish-dialog-title']}>
           <div>Publish to </div>
           <EnvironmentDropdown
-            environments={environments}
+            environments={parsedEnvironments}
             initialSelectedEnvironment={environment}
             onChange={(selected) => setEnvironment(selected)}
             disabled={isInProgess}
@@ -44,7 +43,9 @@ export default function PublishToEnvironmentDialog({
       }
       confirmLabel={`Publish to ${environment.value}`}
       onCancel={onCancel}
-      onConfirm={() => onConfirm(environment.id)}
+      onConfirm={() =>
+        onConfirm({ envId: environment.id, envName: environment.label ?? environment.value })
+      }
       loadingConfirmButton={isInProgess}
       disableDialog={isInProgess}
     >

--- a/src/components/common/dialogs/PublishToEnvironmentDialog/index.tsx
+++ b/src/components/common/dialogs/PublishToEnvironmentDialog/index.tsx
@@ -41,11 +41,12 @@ export default function PublishToEnvironmentDialog({
           />
         </div>
       }
+      confirmClass={classes['confirmation-button']}
       confirmLabel={`Publish to ${environment.value}`}
-      onCancel={onCancel}
       onConfirm={() =>
         onConfirm({ envId: environment.id, envName: environment.label ?? environment.value })
       }
+      onCancel={onCancel}
       loadingConfirmButton={isInProgess}
       disableDialog={isInProgess}
     >

--- a/src/components/common/dialogs/PublishToEnvironmentDialog/style.module.scss
+++ b/src/components/common/dialogs/PublishToEnvironmentDialog/style.module.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/mixins';
+
 .publish-dialog-title {
   display: flex;
   align-items: baseline;
@@ -15,5 +17,13 @@ ul.publish-dialog-ul {
     svg {
       margin-right: 5px;
     }
+  }
+}
+
+.confirmation-button {
+  max-width: 240px;
+
+  > span:last-child {
+    @include ellipsis();
   }
 }

--- a/src/providers/AppContext/actions.ts
+++ b/src/providers/AppContext/actions.ts
@@ -5,6 +5,7 @@ export enum ActionType {
   SetUser = 'SET_USER',
   SetSystem = 'SET_SYSTEM',
   SetEnvironment = 'SET_ENVIRONMENT',
+  SetEnvironments = 'SET_ENVIRONMENTS',
   SetDateRange = 'SET_DATE_RANGE',
   CurrentScreenProvider = 'CURRENT_SCREEN_PROVIDER',
   ResetAppState = 'RESET_APP_STATE',

--- a/src/providers/AppContext/app-context.interface.ts
+++ b/src/providers/AppContext/app-context.interface.ts
@@ -5,6 +5,7 @@ import { WalkMeEnvironment } from '@walkme/editor-sdk/dist/environment';
 
 import { EnvironmentType } from '../../interfaces/app.interfaces';
 import { IDateRange } from '../../utils';
+import { IWMDropdownOption } from '../../components/common/WMDropdown';
 
 import { ActionType } from './actions';
 
@@ -17,6 +18,7 @@ export interface IAction {
   user?: UserData;
   originalUser?: UserData;
   system?: SystemData | string; // string type for non-system-users - temporary solution
+  environments?: WalkMeEnvironment[];
   environment?: WalkMeEnvironment;
   dateRange?: IDateRange;
 }
@@ -34,6 +36,8 @@ export interface IState {
   originalUser: UserData;
   system: SystemData | string; // string type for non-system-users - temporary solution
   environment: WalkMeEnvironment;
+  environments: WalkMeEnvironment[];
+  parsedEnvironments: IWMDropdownOption[];
   dateRange: IDateRange;
 }
 

--- a/src/providers/AppContext/reducer.ts
+++ b/src/providers/AppContext/reducer.ts
@@ -3,6 +3,8 @@ import { UserData } from '@walkme/editor-sdk/dist/user';
 import { WalkMeEnvironment } from '@walkme/editor-sdk/dist/environment';
 import { SystemData } from '@walkme/editor-sdk/dist/system';
 
+import { parseEnvironments } from '../../components/Layout/HeaderToolbar/utils';
+import { IWMDropdownOption } from '../../components/common/WMDropdown';
 import { defaultDateRange } from '../../utils';
 
 import { ActionType, IState, IAction } from './app-context.interface';
@@ -15,6 +17,8 @@ export const initialState = {
   user: {} as UserData,
   system: {} as SystemData,
   environment: {} as WalkMeEnvironment,
+  environments: {} as WalkMeEnvironment[],
+  parsedEnvironments: [] as IWMDropdownOption[],
   originalUser: {} as UserData,
   dateRange: defaultDateRange,
 };
@@ -45,6 +49,10 @@ export const reducer = produce(
         break;
       case ActionType.SetSystem:
         draft.system = action.system ?? initialState.system;
+        break;
+      case ActionType.SetEnvironments:
+        draft.environments = action.environments ?? [];
+        draft.parsedEnvironments = parseEnvironments(action.environments ?? []);
         break;
       case ActionType.SetEnvironment:
         draft.environment = action.environment ?? initialState.environment;

--- a/src/providers/AppContext/utils.ts
+++ b/src/providers/AppContext/utils.ts
@@ -35,10 +35,13 @@ export const setInitialGlobals = async (dispatch: IDispatch): Promise<void> => {
   dispatch({ type: ActionType.Updating });
 
   try {
-    const user = await walkme.getUserData();
-    const originalUser = await walkme.getOriginalUserData();
-    const system = await walkme.getSystemData();
-    const environments = await walkme.getEnvironments();
+    const [user, originalUser, system, environments] = await Promise.all([
+      walkme.getUserData(),
+      walkme.getOriginalUserData(),
+      walkme.getSystemData(),
+      walkme.getEnvironments(),
+    ]);
+
     const defaultEnv = environments.find(
       (env: WalkMeEnvironment) => env.id === EnvironmentType.Production,
     );
@@ -46,6 +49,7 @@ export const setInitialGlobals = async (dispatch: IDispatch): Promise<void> => {
     dispatch({ type: ActionType.SetUser, user });
     dispatch({ type: ActionType.SetOriginalUser, originalUser });
     dispatch({ type: ActionType.SetSystem, system });
+    dispatch({ type: ActionType.SetEnvironments, environments });
     dispatch({ type: ActionType.SetEnvironment, environment: defaultEnv });
 
     dispatch({ type: ActionType.UpdateSuccess });

--- a/src/providers/CoursesContext/utils.ts
+++ b/src/providers/CoursesContext/utils.ts
@@ -11,7 +11,6 @@ import {
 } from '../../walkme';
 import { UICourse } from '../../walkme/data';
 import { wmMessage, MessageType, pluralizer } from '../../utils';
-import { EnvironmentType } from '../../interfaces/app.interfaces';
 
 import { ActionType, IState, IDispatch } from './courses-context.interface';
 
@@ -122,14 +121,10 @@ export const deleteCourses = async (
   }
 };
 
-const envNames = {
-  [EnvironmentType.Production]: 'production',
-  [EnvironmentType.Test]: 'test',
-};
-
 export const publishCourses = async (
   dispatch: IDispatch,
   envId: number,
+  envName: string,
   courses: Array<UICourse>,
 ): Promise<void> => {
   dispatch({ type: ActionType.PublishCourses });
@@ -139,11 +134,7 @@ export const publishCourses = async (
     await _publishCourses(envId, coursesIds);
 
     dispatch({ type: ActionType.PublishCoursesSuccess });
-    wmMessage(
-      `${courses.length} ${pluralizer('course', courses.length)} published to ${
-        envNames[envId as keyof typeof envNames]
-      }`,
-    );
+    wmMessage(`${courses.length} ${pluralizer('course', courses.length)} published to ${envName}`);
   } catch (error) {
     console.error(error);
     dispatch({ type: ActionType.PublishCoursesError });
@@ -154,6 +145,7 @@ export const publishCourses = async (
 export const archiveCourses = async (
   dispatch: IDispatch,
   envId: number,
+  envName: string,
   courses: Array<UICourse>,
 ): Promise<void> => {
   dispatch({ type: ActionType.ArchiveCourses });
@@ -163,11 +155,7 @@ export const archiveCourses = async (
     await _archiveCourses(envId, coursesIds);
 
     dispatch({ type: ActionType.ArchiveCoursesSuccess });
-    wmMessage(
-      `${courses.length} ${pluralizer('course', courses.length)} archived to ${
-        envNames[envId as keyof typeof envNames]
-      }`,
-    );
+    wmMessage(`${courses.length} ${pluralizer('course', courses.length)} published to ${envName}`);
   } catch (error) {
     console.error(error);
     dispatch({ type: ActionType.ArchiveCoursesError });


### PR DESCRIPTION
- Makes `test` the default env for publish/archive.
- Refactors `enviroments` handling: Moves `enviroments` and `parsedEnvironments` to `AppContext`.
- Fixes button overflow in publish and archive dialogs (also updates `WMDial` footer styling for it to work).

Other fixes:
- Makes `setInitialGlobals()` more efficient.
- Fixes impersonate dialog classes leaking to global scope.