### PR TITLE
Quiz charts state

### DIFF
--- a/src/components/Layout/HeaderToolbar/EnvironmentMenu.tsx
+++ b/src/components/Layout/HeaderToolbar/EnvironmentMenu.tsx
@@ -21,7 +21,7 @@ export default function EnvironmentMenu({ className }: { className?: string }): 
     setAppEnvironment({
       dispatch,
       environments,
-      envId: parseInt(selected.id as string),
+      envId: parseInt(selected.id as string, 10),
     });
     setSelectedEnv(selected);
 

--- a/src/components/Layout/HeaderToolbar/SystemMenu.tsx
+++ b/src/components/Layout/HeaderToolbar/SystemMenu.tsx
@@ -24,7 +24,7 @@ export default function SystemMenu({ className }: { className?: string }): React
     setAppSystem({
       dispatch,
       systems,
-      systemId: parseInt(selected.id as string),
+      systemId: parseInt(selected.id as string, 10),
     });
 
     message.info(`System changed to ${selected.value}`);

--- a/src/components/Screen/CourseEditorScreen/QuizSettingsForm/index.tsx
+++ b/src/components/Screen/CourseEditorScreen/QuizSettingsForm/index.tsx
@@ -25,9 +25,9 @@ export default function QuizSettingsForm({ courseId }: { courseId: number }): Re
   const onPassmarkChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     const reg = /^-?\d*(\.\d*)?$/;
-    if ((!isNaN(parseInt(value)) && reg.test(value)) || value === '' || value === '-') {
+    if ((!isNaN(parseInt(value, 10)) && reg.test(value)) || value === '' || value === '-') {
       const quizPassmark =
-        value === '' || value === '-' ? 0 : parseInt(value) > 100 ? 100 : parseInt(value);
+        value === '' || value === '-' ? 0 : parseInt(value, 10) > 100 ? 100 : parseInt(value, 10);
 
       if (quiz) {
         quiz.properties = { ...quiz.properties, ...{ passmark: quizPassmark } };

--- a/src/components/common/AnalyticsCharts/CourseTimeCompletionChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/CourseTimeCompletionChart/index.tsx
@@ -24,7 +24,7 @@ export default function CoursesTimeCompletionChart({
       const { completion_time } = overview;
 
       setCompletionTimeAvg(
-        completion_time.avg ? parseInt(completion_time.avg.toFixed(0)) : undefined,
+        completion_time.avg ? parseInt(completion_time.avg.toFixed(0), 10) : undefined,
       );
 
       if (completion_time.buckets.length)

--- a/src/components/common/AnalyticsCharts/CourseTimeCompletionChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/CourseTimeCompletionChart/index.tsx
@@ -20,7 +20,7 @@ export default function CoursesTimeCompletionChart({
   const [bars, setBars] = useState<IBar[]>([]);
 
   useEffect(() => {
-    if (overview?.completion_time) {
+    if (overview?.completion_time?.avg) {
       const { completion_time } = overview;
 
       setCompletionTimeAvg(
@@ -29,6 +29,9 @@ export default function CoursesTimeCompletionChart({
 
       if (completion_time.buckets.length)
         setBars(parseBucketsToPieBarSummary(completion_time.buckets));
+    } else {
+      setBars([]);
+      setCompletionTimeAvg(undefined);
     }
   }, [overview]);
 

--- a/src/components/common/AnalyticsCharts/CourseTimeCompletionChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/CourseTimeCompletionChart/index.tsx
@@ -29,10 +29,12 @@ export default function CoursesTimeCompletionChart({
 
       if (completion_time.buckets.length)
         setBars(parseBucketsToPieBarSummary(completion_time.buckets));
-    } else {
+    }
+
+    return () => {
       setBars([]);
       setCompletionTimeAvg(undefined);
-    }
+    };
   }, [overview]);
 
   // unmount only

--- a/src/components/common/AnalyticsCharts/QuizCompletionRateChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/QuizCompletionRateChart/index.tsx
@@ -34,13 +34,16 @@ export default function QuizCompletionRateChart({
   }, [overview]);
 
   useEffect(() => {
-    if (totalPercentages)
+    if (totalPercentages) {
       setBars([
         {
           value: totalPercentages,
           legend: 'Users who completed a course',
         },
       ]);
+    } else {
+      setBars([]);
+    }
   }, [totalPercentages]);
 
   // unmount only

--- a/src/components/common/AnalyticsCharts/QuizCompletionRateChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/QuizCompletionRateChart/index.tsx
@@ -41,9 +41,9 @@ export default function QuizCompletionRateChart({
           legend: 'Users who completed a course',
         },
       ]);
-    } else {
-      setBars([]);
     }
+
+    return () => setBars([]);
   }, [totalPercentages]);
 
   // unmount only

--- a/src/components/common/AnalyticsCharts/QuizCompletionRateChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/QuizCompletionRateChart/index.tsx
@@ -1,4 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { CourseOverviewData } from '../../../../walkme/models';
 
 import CourseQuizEmptyState from '../../../Screen/CourseScreen/CourseQuizEmptyState';
 
@@ -18,15 +21,15 @@ export default function QuizCompletionRateChart({
   overview,
   isLoading = false,
 }: IQuizCompletionRateChart): ReactElement {
+  const { courseId } = useParams();
   const [totalPercentages, setTotalPercentages] = useState<number>();
   const [bars, setBars] = useState<IBar[]>([]);
+  const singleCourseHasQuiz = courseId && (overview as CourseOverviewData).hasQuiz;
 
   useEffect(() => {
     if (overview) {
       const { users_passed, users_submitted } = overview;
-
-      if (users_passed && users_submitted)
-        setTotalPercentages(calculatePercentages(users_passed, users_submitted));
+      setTotalPercentages(calculatePercentages(users_passed, users_submitted));
     }
   }, [overview]);
 
@@ -43,7 +46,7 @@ export default function QuizCompletionRateChart({
   // unmount only
   useEffect(
     () => () => {
-      setTotalPercentages(0);
+      setTotalPercentages(undefined);
       setBars([]);
     },
     [],
@@ -53,7 +56,7 @@ export default function QuizCompletionRateChart({
     <WMCard title={title}>
       <WMSkeleton loading={isLoading} active paragraph={{ rows: 2 }}>
         <div className={className}>
-          {totalPercentages ? (
+          {!courseId || singleCourseHasQuiz ? (
             <>
               <PieBarSummary
                 value={totalPercentages as number}

--- a/src/components/common/AnalyticsCharts/QuizScoreChart/index.tsx
+++ b/src/components/common/AnalyticsCharts/QuizScoreChart/index.tsx
@@ -15,7 +15,7 @@ export default function QuizScoreChart({
   overview,
   isLoading = false,
 }: IQuizScoreData): ReactElement {
-  const { avg_quiz_score, passmark } = overview;
+  const { hasQuiz, avg_quiz_score, passmark } = overview;
 
   // `avg_quiz_score` is required in type `CourseOverviewData`, and returns `null` when data is missing
   const average = avg_quiz_score ? Math.round(avg_quiz_score) : undefined;
@@ -25,19 +25,18 @@ export default function QuizScoreChart({
     <WMCard title="Avg. Quiz Score" className={classes['course-average']}>
       <WMSkeleton loading={isLoading} active paragraph={{ rows: 1 }}>
         <div className={classes['course-average-content']}>
-          {hasValue ? (
+          {hasQuiz && hasValue ? (
             <>
               <WMProgress
                 className={classes['course-average-chart']}
                 percent={average}
                 type={ProgressType.Circle}
-                format={() => average ?? 0}
+                format={() => average ?? '--'}
                 width={80}
                 strokeWidth={10}
                 status={
-                  passmark && average! > passmark
-                    ? ProgressStatus.Success
-                    : ProgressStatus.Exception
+                  // using `hasQuiz && hasValue` to verify if average or passmark is not undefined, therefor using ! operator
+                  average! > passmark! ? ProgressStatus.Success : ProgressStatus.Exception
                 }
               />
               <span className={classes['passmark']}>

--- a/src/components/common/AnalyticsCharts/utils.ts
+++ b/src/components/common/AnalyticsCharts/utils.ts
@@ -6,8 +6,8 @@ import { IBar } from '../charts/PieBarChart/pieBarChart.interface';
 
 import { ICourseSummaryLegendData } from './analytics.interface';
 
-export const calculatePercentages = (first: number, second: number): number =>
-  Boolean(first) && Boolean(second) ? parseInt(((first / second) * 100).toFixed(2)) : 0;
+export const calculatePercentages = (first: number, second: number): number | undefined =>
+  Boolean(first) && Boolean(second) ? parseInt(((first / second) * 100).toFixed(2)) : undefined;
 
 export const parseCourseSummaryLegendData = ({
   total_completion,

--- a/src/components/common/AnalyticsCharts/utils.ts
+++ b/src/components/common/AnalyticsCharts/utils.ts
@@ -36,5 +36,5 @@ export const formatMarkCompletionDate = (
 export const parseBucketsToPieBarSummary = (buckets: any[]): IBar[] =>
   buckets.map(({ users_percentages, from, to }) => ({
     value: users_percentages.toFixed(2),
-    legend: to ? `${parseInt(from) + parseInt(to)}` : '12', // TODO: verify with Eli if is correct data
+    legend: to ? `${parseInt(from, 10) + parseInt(to, 10)}` : '12', // TODO: verify with Eli if is correct data
   }));

--- a/src/components/common/charts/PieBarChart/index.tsx
+++ b/src/components/common/charts/PieBarChart/index.tsx
@@ -35,7 +35,7 @@ export default function PieBarChart({
           const barColor = bar.color ?? generatedColors[index];
           const legendContent = (
             <LegendContent
-              barValue={barValue}
+              barValue={Math.round(parseInt(barValue, 10))}
               barLegend={barLegend}
               totalValue={totalValue}
               barColor={barColor}

--- a/src/walkme/data/overview/single.ts
+++ b/src/walkme/data/overview/single.ts
@@ -13,5 +13,6 @@ export async function getCourseOverview(
   return {
     ...overviewData,
     passmark: course.quiz?.properties.passmark,
+    hasQuiz: !!course.quiz,
   };
 }

--- a/src/walkme/models/course/panels.ts
+++ b/src/walkme/models/course/panels.ts
@@ -9,4 +9,6 @@ export type CourseOverviewData = AllCoursesOverviewResponse & {
   avg_quiz_score: number;
   /** Passmark score for the quiz of this score */
   passmark?: number;
+  /** true if the course includes quiz */
+  hasQuiz?: boolean;
 };


### PR DESCRIPTION
- In courses screen
        - Quiz Completion Rate if no data renders an empty state.
        - State issue fixed
- In the single course screen:
        - sections Quiz Completion Rate & Avg. Quiz Score - Added cases to render the data | empty state | no quiz.
