### PR TITLE
Course editor outline buttons bug fixes

### DIFF
--- a/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/style.module.scss
+++ b/src/components/Screen/CourseEditorScreen/CourseOutlineQuiz/style.module.scss
@@ -46,6 +46,7 @@
     padding-left: 6px; // align the icons with the list items icons
 
     .delete-button {
+      font-size: 16px;
       opacity: 0;
       margin-left: auto;
       margin-right: 20px;

--- a/src/components/common/buttons/AddButton/style.module.scss
+++ b/src/components/common/buttons/AddButton/style.module.scss
@@ -21,7 +21,7 @@
     &:global(.ant-btn) {
       height: 26px;
       width: auto;
-      padding: 10px;
+      padding: 0 10px;
       border-radius: 15px;
       text-transform: uppercase;
       font-size: 12px;


### PR DESCRIPTION
- Fix Safari `AddButton` bug (see [this task on Trello](https://trello.com/c/YMqQ3gcU/247-course-editor-add-button-redesign)).
- Fix question-item's delete-button height bug (noticeable only in Safari, see attachment).

![image](https://user-images.githubusercontent.com/39803793/91988040-7af3be80-ed37-11ea-8a5f-25a85740afd1.png)
