### PR TITLE
Users table width fix

### DIFF
--- a/src/components/Screen/UsersScreen/style.module.scss
+++ b/src/components/Screen/UsersScreen/style.module.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/mixins';
+
 .users-screen {
   min-width: min-content;
 
@@ -7,7 +9,7 @@
   }
 
   .table-wrapper:global(.ant-card) {
-    min-width: min-content;
+    min-width: 1060px;
 
     .shown-users-indicator {
       font-family: var(--font-secondary);
@@ -59,34 +61,15 @@
 
           // Needed in order to control table body height
           max-height: var(--table-body-height) !important;
-
-          > table {
-            // Needed in order to control table columns width
-            table-layout: auto !important;
-          }
         }
 
         .user-cell {
           font-weight: 600;
-          min-width: 290px;
         }
 
+        .user-cell,
         .course-name-cell {
-          min-width: 280px;
-        }
-
-        .started-cell,
-        .completed-cell,
-        .duration-cell {
-          min-width: 120px;
-        }
-
-        .result-cell {
-          min-width: 90px;
-        }
-
-        .attempts-cell {
-          min-width: 130px;
+          @include ellipsis;
         }
       }
     }

--- a/src/components/Screen/UsersScreen/style.module.scss
+++ b/src/components/Screen/UsersScreen/style.module.scss
@@ -1,5 +1,3 @@
-@import 'src/styles/mixins';
-
 .users-screen {
   min-width: min-content;
 
@@ -63,13 +61,36 @@
           max-height: var(--table-body-height) !important;
         }
 
-        .user-cell {
-          font-weight: 600;
+        // Hides `thead` scrollbar
+        :global(.ant-table-cell-scrollbar) {
+          box-shadow: none;
         }
 
-        .user-cell,
-        .course-name-cell {
-          @include ellipsis;
+        // Resets relevant 'antd' `table` columns width
+        colgroup col:not(:first-child):not(:nth-child(2)):not(:last-child) {
+          width: unset !important;
+          min-width: 0 !important;
+        }
+
+        .started-cell,
+        .result-cell {
+          min-width: 13%;
+          width: 13%;
+        }
+
+        .completed-cell,
+        .duration-cell {
+          min-width: 14.5%;
+          width: 14.5%;
+        }
+
+        .attempts-cell {
+          min-width: 15.5%;
+          width: 15.5%;
+        }
+
+        .user-cell {
+          font-weight: 600;
         }
       }
     }

--- a/src/components/Screen/UsersScreen/tableData.tsx
+++ b/src/components/Screen/UsersScreen/tableData.tsx
@@ -12,6 +12,7 @@ import {
   StatusDotCell,
   SubtextCell,
 } from '../../common/tableCells';
+import WMPopover from '../../common/WMPopover';
 
 import classes from './style.module.scss';
 
@@ -28,7 +29,9 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
       onClick: () => onClick(col),
     }),
     render: (value: string): ReactElement => (
-      <TextCell className={classes['user-cell']} value={value} />
+      <WMPopover content={value}>
+        <TextCell className={classes['user-cell']} value={value} />
+      </WMPopover>
     ),
   },
   {
@@ -39,7 +42,9 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
       onClick: () => onClick(col),
     }),
     render: (value: string): ReactElement => (
-      <TextCell className={classes['course-name-cell']} value={value} />
+      <WMPopover content={value}>
+        <TextCell className={classes['course-name-cell']} value={value} />
+      </WMPopover>
     ),
   },
   {

--- a/src/components/Screen/UsersScreen/tableData.tsx
+++ b/src/components/Screen/UsersScreen/tableData.tsx
@@ -26,7 +26,6 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     sorter: true,
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
-      className: classes['user-cell'],
     }),
     render: (value: string): ReactElement => (
       <TextCell className={classes['user-cell']} value={value} />
@@ -38,7 +37,6 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     sorter: true,
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
-      className: classes['course-name-cell'],
     }),
     render: (value: string): ReactElement => (
       <TextCell className={classes['course-name-cell']} value={value} />
@@ -48,50 +46,45 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     title: 'Started',
     dataIndex: UsersColumn.STARTED_DATE,
     sorter: true,
+    width: '13%',
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
-      className: classes['started-cell'],
     }),
     render: (value: Date): ReactElement => {
       const range = moment(value).fromNow();
       const formattedDate = moment(value).format(tableDateFormat);
 
-      return (
-        <SubtextCell className={classes['started-cell']} value={range} subtext={formattedDate} />
-      );
+      return <SubtextCell value={range} subtext={formattedDate} />;
     },
   },
   {
     title: 'Completed',
     dataIndex: UsersColumn.COMPLETED_DATE,
     sorter: true,
+    width: '14.5%',
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
-      className: classes['completed-cell'],
     }),
     render: (value: Date): ReactElement => {
       const range = moment(value).fromNow();
       const formattedDate = moment(value).format(tableDateFormat);
 
       return value ? (
-        <SubtextCell className={classes['completed-cell']} value={range} subtext={formattedDate} />
+        <SubtextCell value={range} subtext={formattedDate} />
       ) : (
-        <WarningCell className={classes['completed-cell']} value="Did not complete" />
+        <WarningCell value="Did not complete" />
       );
     },
   },
   {
     title: 'Time to Complete',
     dataIndex: UsersColumn.TIME_TO_COMPLETE,
-    onHeaderCell: () => ({ className: classes['duration-cell'] }),
+    width: '14.5%',
     render: (value: string): ReactElement =>
       value ? (
-        <NumberCell
-          className={classes['duration-cell']}
-          value={moment.duration(value, 'milliseconds').humanize()}
-        />
+        <NumberCell value={moment.duration(value, 'milliseconds').humanize()} />
       ) : (
-        <WarningCell className={classes['duration-cell']} value="Did not complete" />
+        <WarningCell value="Did not complete" />
       ),
   },
   {
@@ -99,15 +92,15 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     dataIndex: UsersColumn.QUIZ_RESULT,
     align: 'right',
     sorter: true,
+    width: '11%',
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
-      className: classes['result-cell'],
     }),
     render: (value: number, { quiz_passed }: UserListUILineItem): ReactElement =>
       isValidNumber(value) ? (
-        <StatusDotCell className={classes['result-cell']} value={value} passed={quiz_passed} />
+        <StatusDotCell value={value} passed={quiz_passed} />
       ) : (
-        <WarningCell className={classes['result-cell']} value="Did not submit" />
+        <WarningCell value="Did not submit" />
       ),
   },
   {
@@ -115,15 +108,11 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     dataIndex: UsersColumn.QUIZ_ATTEMPTS,
     align: 'right',
     sorter: true,
+    width: '15.5%',
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
-      className: classes['attempts-cell'],
     }),
     render: (value: string): ReactElement =>
-      value ? (
-        <NumberCell className={classes['attempts-cell']} value={value} />
-      ) : (
-        <WarningCell className={classes['attempts-cell']} value="Did not complete" />
-      ),
+      value ? <NumberCell value={value} /> : <WarningCell value="Did not complete" />,
   },
 ];

--- a/src/components/Screen/UsersScreen/tableData.tsx
+++ b/src/components/Screen/UsersScreen/tableData.tsx
@@ -12,7 +12,6 @@ import {
   StatusDotCell,
   SubtextCell,
 } from '../../common/tableCells';
-import WMPopover from '../../common/WMPopover';
 
 import classes from './style.module.scss';
 
@@ -29,9 +28,7 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
       onClick: () => onClick(col),
     }),
     render: (value: string): ReactElement => (
-      <WMPopover content={value}>
-        <TextCell className={classes['user-cell']} value={value} />
-      </WMPopover>
+      <TextCell className={classes['user-cell']} value={value} hasPopover />
     ),
   },
   {
@@ -41,17 +38,13 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
     }),
-    render: (value: string): ReactElement => (
-      <WMPopover content={value}>
-        <TextCell className={classes['course-name-cell']} value={value} />
-      </WMPopover>
-    ),
+    render: (value: string): ReactElement => <TextCell value={value} hasPopover />,
   },
   {
     title: 'Started',
     dataIndex: UsersColumn.STARTED_DATE,
     sorter: true,
-    width: '13%',
+    className: classes['started-cell'],
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
     }),
@@ -66,7 +59,7 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     title: 'Completed',
     dataIndex: UsersColumn.COMPLETED_DATE,
     sorter: true,
-    width: '14.5%',
+    className: classes['completed-cell'],
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
     }),
@@ -84,7 +77,7 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
   {
     title: 'Time to Complete',
     dataIndex: UsersColumn.TIME_TO_COMPLETE,
-    width: '14.5%',
+    className: classes['duration-cell'],
     render: (value: string): ReactElement =>
       value ? (
         <NumberCell value={moment.duration(value, 'milliseconds').humanize()} />
@@ -97,7 +90,7 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     dataIndex: UsersColumn.QUIZ_RESULT,
     align: 'right',
     sorter: true,
-    width: '11%',
+    className: classes['result-cell'],
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
     }),
@@ -113,7 +106,7 @@ export const getColumns = (onClick: (col: ColumnType<any>) => void): ColumnsType
     dataIndex: UsersColumn.QUIZ_ATTEMPTS,
     align: 'right',
     sorter: true,
-    width: '15.5%',
+    className: classes['attempts-cell'],
     onHeaderCell: (col) => ({
       onClick: () => onClick(col),
     }),

--- a/src/components/common/tableCells/TextCell.tsx
+++ b/src/components/common/tableCells/TextCell.tsx
@@ -1,11 +1,62 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState, useRef, useEffect, useCallback } from 'react';
+import cc from 'classcat';
+import { useDebounceCallback } from '@react-hook/debounce';
+
+import WMPopover from '../WMPopover';
 
 import { ITextCell } from './tableCells.interface';
+import classes from './style.module.scss';
 
-export default function TextCell({ value, className, ...otherProps }: ITextCell): ReactElement {
+export default function TextCell({
+  value,
+  className,
+  hasPopover = false,
+  ...otherProps
+}: ITextCell): ReactElement {
+  const textCellRef = useRef<HTMLDivElement>(null);
+  const [content, setContent] = useState(value);
+  const [hasEllipsis, setHasEllipsis] = useState(false);
+
+  const compareSize = useCallback(() => {
+    if (textCellRef.current && textCellRef.current.scrollWidth > textCellRef.current.clientWidth) {
+      setHasEllipsis(true);
+      setContent(
+        <WMPopover content={<span>{value}</span>}>
+          <span>{value}</span>
+        </WMPopover>,
+      );
+    } else {
+      setHasEllipsis(false);
+      setContent(value);
+    }
+  }, [value]);
+
+  const debouncedCompareSize = useDebounceCallback(compareSize, 1000);
+
+  // compare once and add resize listener on mount
+  useEffect(() => {
+    if (!hasPopover) return;
+
+    compareSize();
+
+    window.addEventListener('resize', debouncedCompareSize);
+  }, [hasPopover, compareSize, debouncedCompareSize]);
+
+  // remove resize listener on unmount
+  useEffect(
+    () => () => {
+      window.removeEventListener('resize', debouncedCompareSize);
+    },
+    [debouncedCompareSize],
+  );
+
   return (
-    <div className={className} {...otherProps}>
-      {value}
+    <div
+      ref={textCellRef}
+      className={cc([classes['text-cell'], className, { [classes['has-ellipsis']]: hasEllipsis }])}
+      {...otherProps}
+    >
+      {content}
     </div>
   );
 }

--- a/src/components/common/tableCells/style.module.scss
+++ b/src/components/common/tableCells/style.module.scss
@@ -16,6 +16,16 @@ a.link-cell {
   }
 }
 
+.text-cell {
+  overflow: auto;
+  white-space: nowrap;
+
+  &.has-ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
 .subtext-cell {
   .text {
     font-weight: 500;

--- a/src/components/common/tableCells/tableCells.interface.ts
+++ b/src/components/common/tableCells/tableCells.interface.ts
@@ -41,6 +41,7 @@ export interface ITextArrayCell extends ITableCell {
 
 export interface ITextCell extends ITableCell {
   value: ReactNode;
+  hasPopover?: boolean;
 }
 
 export interface IIconTextCell extends ITableCell {


### PR DESCRIPTION
- Updated 'users-table' and its columns width, to meet requirements. See [this Trello task](https://trello.com/c/mOUU0OTA/248-users-table-is-too-wide-and-requires-scrolling-in-order-to-see-all-columns-also-search-bar-is-partially-hidden).
- Added popovers to 'user' and 'course name' column-cells. Since these columns width is dynamic and depends on the viewport size, there's no sure way to render the popover conditionally, i.e. the popovers are always visible on hover.